### PR TITLE
PDM changes + bugfix and cleanup

### DIFF
--- a/installerfw.pri
+++ b/installerfw.pri
@@ -144,7 +144,7 @@ equals(TEMPLATE, app) {
 # Protobuf
 # LIBS += -L$$PWD/src/libs/protobuf/lib/ -llibprotobuf
 # INCLUDEPATH += $$PWD/src/libs/protobuf/include
-PROTOBUF_PATH = /eve_installer/protobuf/v3.6.0
+PROTOBUF_PATH = c:/eve_installer/protobuf/v3.6.0
 LIBS += -L$$PROTOBUF_PATH/lib/ -llibprotobuf
 INCLUDEPATH += $$PROTOBUF_PATH/include
 
@@ -152,7 +152,7 @@ INCLUDEPATH += $$PROTOBUF_PATH/include
 # LIBS += -L$$PWD/src/libs/pdm/libs/Windows/x32/MT/ -lpdm -lplatform_pdm_proto_wrapper
 # INCLUDEPATH += $$PWD/src/libs/pdm/include
 # INCLUDEPATH += $$PWD/src/libs/pdm/include/generated
-PDM_PATH = /eve_installer/pdm-proto
+PDM_PATH = c:/eve_installer/pdm-proto
 LIBS += -L$$PDM_PATH/libs/Windows/x32/MT/ -lpdm -lplatform_pdm_proto_wrapper
 INCLUDEPATH += $$PDM_PATH/include
 INCLUDEPATH += $$PDM_PATH/include/generated

--- a/src/libs/installer/eventlogger.cpp
+++ b/src/libs/installer/eventlogger.cpp
@@ -26,7 +26,7 @@ EventLogger::EventLogger()
 
     m_sessionId = hasher.result();
 
-    std::string osUuidString = PDM::GetMachineUuid();
+    std::string osUuidString = PDM::GetMachineUuidString();
     QUuid osUuid = QUuid::fromString(QString::fromStdString(osUuidString));
     m_operatingSystemUuid = osUuid.toRfc4122();
 

--- a/src/libs/installer/eventlogger.cpp
+++ b/src/libs/installer/eventlogger.cpp
@@ -199,9 +199,9 @@ void EventLogger::uninstallerPageDisplayed(eve_launcher::uninstaller::Page previ
 {
     auto evt = new eve_launcher::uninstaller::PageDisplayed;
     evt->set_allocated_event_metadata(getEventMetadata());
-    evt->set_previous_page(static_cast<eve_launcher::uninstaller::Page>(previousPage));
-    evt->set_current_page(static_cast<eve_launcher::uninstaller::Page>(currentPage));
-    evt->set_flow(static_cast<eve_launcher::uninstaller::PageDisplayed_FlowDirection>(flow));
+    evt->set_previous_page(previousPage);
+    evt->set_current_page(currentPage);
+    evt->set_flow(flow);
     sendAllocatedEvent(evt);
 }
 
@@ -209,8 +209,8 @@ void EventLogger::uninstallerShutDown(eve_launcher::uninstaller::Page page, eve_
 {
     auto evt = new eve_launcher::uninstaller::ShutDown;
     evt->set_allocated_event_metadata(getEventMetadata());
-    evt->set_page(static_cast<eve_launcher::uninstaller::Page>(page));
-    evt->set_state(static_cast<eve_launcher::uninstaller::ShutDown_State>(state));
+    evt->set_page(page);
+    evt->set_state(state);
     evt->set_finish_button(finishButton);
     sendAllocatedEvent(evt);
     m_httpThreadController->lastChanceToFinish();
@@ -265,8 +265,8 @@ void EventLogger::uninstallerErrorEncountered(eve_launcher::uninstaller::ErrorEn
 {
     auto evt = new eve_launcher::uninstaller::ErrorEncountered;
     evt->set_allocated_event_metadata(getEventMetadata());
-    evt->set_code(static_cast<eve_launcher::uninstaller::ErrorEncountered_ErrorCode>(code));
-    evt->set_page(static_cast<eve_launcher::uninstaller::Page>(page));
+    evt->set_code(code);
+    evt->set_page(page);
     sendAllocatedEvent(evt);
 }
 
@@ -293,9 +293,9 @@ void EventLogger::installerPageDisplayed(eve_launcher::installer::Page previousP
 {
     auto evt = new eve_launcher::installer::PageDisplayed;
     evt->set_allocated_event_metadata(getEventMetadata());
-    evt->set_previous_page(static_cast<eve_launcher::installer::Page>(previousPage));
-    evt->set_current_page(static_cast<eve_launcher::installer::Page>(currentPage));
-    evt->set_flow(static_cast<eve_launcher::installer::PageDisplayed_FlowDirection>(flow));
+    evt->set_previous_page(previousPage);
+    evt->set_current_page(currentPage);
+    evt->set_flow(flow);
     sendAllocatedEvent(evt);
 }
 
@@ -303,8 +303,8 @@ void EventLogger::installerShutDown(eve_launcher::installer::Page page, eve_laun
 {
     auto evt = new eve_launcher::installer::ShutDown;
     evt->set_allocated_event_metadata(getEventMetadata());
-    evt->set_page(static_cast<eve_launcher::installer::Page>(page));
-    evt->set_state(static_cast<eve_launcher::installer::ShutDown_State>(state));
+    evt->set_page(page);
+    evt->set_state(state);
     evt->set_finish_button(finishButton);
     sendAllocatedEvent(evt);
     m_httpThreadController->lastChanceToFinish();
@@ -329,8 +329,8 @@ void EventLogger::installerLocationChanged(eve_launcher::installer::LocationChan
 {
     auto evt = new eve_launcher::installer::LocationChanged;
     evt->set_allocated_event_metadata(getEventMetadata());
-    evt->set_source(static_cast<eve_launcher::installer::LocationChanged_Source>(source));
-    evt->set_provider(static_cast<eve_launcher::installer::LocationChanged_Provider>(provider));
+    evt->set_source(source);
+    evt->set_provider(provider);
     evt->set_path(path.toStdString());
     sendAllocatedEvent(evt);
 }
@@ -381,8 +381,8 @@ void EventLogger::installerRedistSearchConcluded(eve_launcher::installer::Redist
 {
     auto evt = new eve_launcher::installer::RedistSearchConcluded;
     evt->set_allocated_event_metadata(getEventMetadata());
-    evt->set_version(static_cast<eve_launcher::installer::RedistVersion>(version));
-    evt->set_reason(static_cast<eve_launcher::installer::RedistSearchConcluded_RedistReason>(reason));
+    evt->set_version(version);
+    evt->set_reason(reason);
     sendAllocatedEvent(evt);
 }
 
@@ -404,7 +404,7 @@ void EventLogger::installerSharedCacheMessageClosed(eve_launcher::installer::Mes
 {
     auto evt = new eve_launcher::installer::SharedCacheMessageClosed;
     evt->set_allocated_event_metadata(getEventMetadata());
-    evt->set_message_box_button(static_cast<eve_launcher::installer::MessageBoxButton>(messageBoxButton));
+    evt->set_message_box_button(messageBoxButton);
     evt->set_time_displayed(timeDisplayed);
     sendAllocatedEvent(evt);
 }
@@ -459,8 +459,8 @@ void EventLogger::installerComponentInitializationStarted(eve_launcher::installe
 {
     auto evt = new eve_launcher::installer::ComponentInitializationStarted;
     evt->set_allocated_event_metadata(getEventMetadata());
-    evt->set_component(static_cast<eve_launcher::installer::Component>(component));
-    evt->set_redist_version(static_cast<eve_launcher::installer::RedistVersion>(redistVersion));
+    evt->set_component(component);
+    evt->set_redist_version(redistVersion);
     sendAllocatedEvent(evt);
 }
 
@@ -468,8 +468,8 @@ void EventLogger::installerComponentInitializationFinished(eve_launcher::install
 {
     auto evt = new eve_launcher::installer::ComponentInitializationFinished;
     evt->set_allocated_event_metadata(getEventMetadata());
-    evt->set_component(static_cast<eve_launcher::installer::Component>(component));
-    evt->set_redist_version(static_cast<eve_launcher::installer::RedistVersion>(redistVersion));
+    evt->set_component(component);
+    evt->set_redist_version(redistVersion);
     evt->set_duration(duration);
     sendAllocatedEvent(evt);
 }
@@ -478,8 +478,8 @@ void EventLogger::installerComponentInstallationStarted(eve_launcher::installer:
 {
     auto evt = new eve_launcher::installer::ComponentInstallationStarted;
     evt->set_allocated_event_metadata(getEventMetadata());
-    evt->set_component(static_cast<eve_launcher::installer::Component>(component));
-    evt->set_redist_version(static_cast<eve_launcher::installer::RedistVersion>(redistVersion));
+    evt->set_component(component);
+    evt->set_redist_version(redistVersion);
     sendAllocatedEvent(evt);
 }
 
@@ -487,8 +487,8 @@ void EventLogger::installerComponentInstallationFinished(eve_launcher::installer
 {
     auto evt = new eve_launcher::installer::ComponentInstallationFinished;
     evt->set_allocated_event_metadata(getEventMetadata());
-    evt->set_component(static_cast<eve_launcher::installer::Component>(component));
-    evt->set_redist_version(static_cast<eve_launcher::installer::RedistVersion>(redistVersion));
+    evt->set_component(component);
+    evt->set_redist_version(redistVersion);
     evt->set_duration(duration);
     sendAllocatedEvent(evt);
 }
@@ -527,10 +527,10 @@ void EventLogger::installerErrorEncountered(eve_launcher::installer::ErrorEncoun
 {
     auto evt = new eve_launcher::installer::ErrorEncountered;
     evt->set_allocated_event_metadata(getEventMetadata());
-    evt->set_code(static_cast<eve_launcher::installer::ErrorEncountered_ErrorCode>(code));
-    evt->set_page(static_cast<eve_launcher::installer::Page>(page));
-    evt->set_component(static_cast<eve_launcher::installer::Component>(component));
-    evt->set_redist_version(static_cast<eve_launcher::installer::RedistVersion>(redistVersion));
+    evt->set_code(code);
+    evt->set_page(page);
+    evt->set_component(component);
+    evt->set_redist_version(redistVersion);
     sendAllocatedEvent(evt);
 }
 

--- a/src/libs/installer/eventlogger.cpp
+++ b/src/libs/installer/eventlogger.cpp
@@ -205,15 +205,6 @@ void EventLogger::uninstallerPageDisplayed(eve_launcher::uninstaller::Page previ
     sendAllocatedEvent(evt);
 }
 
-void EventLogger::uninstallerUserCancelled(eve_launcher::uninstaller::Page page, eve_launcher::uninstaller::UserCancelled_Progress progress)
-{
-    auto evt = new eve_launcher::uninstaller::UserCancelled;
-    evt->set_allocated_event_metadata(getEventMetadata());
-    evt->set_page(static_cast<eve_launcher::uninstaller::Page>(page));
-    evt->set_progress(static_cast<eve_launcher::uninstaller::UserCancelled_Progress>(progress));
-    sendAllocatedEvent(evt);
-}
-
 void EventLogger::uninstallerShutDown(eve_launcher::uninstaller::Page page, eve_launcher::uninstaller::ShutDown_State state, bool finishButton)
 {
     auto evt = new eve_launcher::uninstaller::ShutDown;
@@ -305,15 +296,6 @@ void EventLogger::installerPageDisplayed(eve_launcher::installer::Page previousP
     evt->set_previous_page(static_cast<eve_launcher::installer::Page>(previousPage));
     evt->set_current_page(static_cast<eve_launcher::installer::Page>(currentPage));
     evt->set_flow(static_cast<eve_launcher::installer::PageDisplayed_FlowDirection>(flow));
-    sendAllocatedEvent(evt);
-}
-
-void EventLogger::installerUserCancelled(eve_launcher::installer::Page page, eve_launcher::installer::UserCancelled_Progress progress)
-{
-    auto evt = new eve_launcher::installer::UserCancelled;
-    evt->set_allocated_event_metadata(getEventMetadata());
-    evt->set_page(static_cast<eve_launcher::installer::Page>(page));
-    evt->set_progress(static_cast<eve_launcher::installer::UserCancelled_Progress>(progress));
     sendAllocatedEvent(evt);
 }
 

--- a/src/libs/installer/eventlogger.h
+++ b/src/libs/installer/eventlogger.h
@@ -20,7 +20,6 @@ public:
     // uninstaller
     void uninstallerStarted(int duration);
     void uninstallerPageDisplayed(eve_launcher::uninstaller::Page previousPage, eve_launcher::uninstaller::Page currentPage, eve_launcher::uninstaller::PageDisplayed_FlowDirection flow);
-    void uninstallerUserCancelled(eve_launcher::uninstaller::Page page, eve_launcher::uninstaller::UserCancelled_Progress progress);
     void uninstallerShutDown(eve_launcher::uninstaller::Page page, eve_launcher::uninstaller::ShutDown_State state, bool finishButton);
     void uninstallerDetailsDisplayed();
     void uninstallerDetailsHidden();
@@ -34,7 +33,6 @@ public:
     // installer
     void installerStarted(int duration);
     void installerPageDisplayed(eve_launcher::installer::Page previousPage, eve_launcher::installer::Page currentPage, eve_launcher::installer::PageDisplayed_FlowDirection flow);
-    void installerUserCancelled(eve_launcher::installer::Page page, eve_launcher::installer::UserCancelled_Progress progress);
     void installerShutDown(eve_launcher::installer::Page page, eve_launcher::installer::ShutDown_State state, bool finishButton);
     void installerPreparationStarted();
     void installerPreparationFinished(int duration);

--- a/src/libs/installer/eventlogger.h
+++ b/src/libs/installer/eventlogger.h
@@ -82,8 +82,8 @@ protected:
     eve_launcher::application::EventMetadata* getEventMetadata();
 
     void sendAllocatedEvent(google::protobuf::Message* payload);
-    QString EventLogger::getGatewayUrl();
-    QByteArray EventLogger::toJsonByteArray(google::protobuf::Message* message);
+    QString getGatewayUrl();
+    QByteArray toJsonByteArray(google::protobuf::Message* message);
     std::string toJson(::google::protobuf::Message* event);
     bool replace(std::string& str, const std::string& from, const std::string& to);
 

--- a/src/libs/installer/installereventoperation.cpp
+++ b/src/libs/installer/installereventoperation.cpp
@@ -154,18 +154,6 @@ bool InstallerEventOperation::sendUninstallerEvent(QStringList args)
 
         EventLogger::instance()->uninstallerPageDisplayed(previousPage, currentPage, flow);
     }
-    else if (event == QString::fromLatin1("UserCancelled") && args.size() == 4)
-    {
-        auto page = toUninstallerPage(&ok, args.at(2));
-        if (!ok) return false;
-
-        id = args.at(3).toInt(&ok);
-        if (!ok) return false;
-        if (!eve_launcher::uninstaller::UserCancelled_Progress_IsValid(id)) return false;
-        auto progress = static_cast<eve_launcher::uninstaller::UserCancelled_Progress>(id);
-
-        EventLogger::instance()->uninstallerUserCancelled(page, progress);
-    }
     else if (event == QString::fromLatin1("ShutDown") && args.size() == 5)
     {
         auto page = toUninstallerPage(&ok, args.at(2));
@@ -268,18 +256,6 @@ bool InstallerEventOperation::sendInstallerEvent(QStringList args)
         auto flow = static_cast<eve_launcher::installer::PageDisplayed_FlowDirection>(id);
 
         EventLogger::instance()->installerPageDisplayed(previousPage, currentPage, flow);
-    }
-    else if (event == QString::fromLatin1("UserCancelled") && args.size() == 4)
-    {
-        auto page = toInstallerPage(&ok, args.at(2));
-        if (!ok) return false;
-
-        id = args.at(3).toInt(&ok);
-        if (!ok) return false;
-        if (!eve_launcher::installer::UserCancelled_Progress_IsValid(id)) return false;
-        auto progress = static_cast<eve_launcher::installer::UserCancelled_Progress>(id);
-
-        EventLogger::instance()->installerUserCancelled(page, progress);
     }
     else if (event == QString::fromLatin1("ShutDown") && args.size() == 5)
     {


### PR DESCRIPTION
- PDM changed their signature from `GetMachineUuid()` to `GetMachineUuidString()`
- Now pointing directly to the libraries with the drive letter as well instead of just the root (this is so that `QtCreator` finds the libraries)
- `UserCancelled` event removed (redundant, `ShutDown` and `InstallationInterrupted` give us all the information we need)
- Cleanup