### PR TITLE
EO-10082 Include protobuf and pdm versions

### DIFF
--- a/installerfw.pri
+++ b/installerfw.pri
@@ -144,7 +144,7 @@ equals(TEMPLATE, app) {
 # Protobuf
 # LIBS += -L$$PWD/src/libs/protobuf/lib/ -llibprotobuf
 # INCLUDEPATH += $$PWD/src/libs/protobuf/include
-PROTOBUF_PATH = c:/eve_installer/protobuf
+PROTOBUF_PATH = c:/eve_installer/protobuf/v3.6.0
 LIBS += -L$$PROTOBUF_PATH/lib/ -llibprotobuf
 INCLUDEPATH += $$PROTOBUF_PATH/include
 
@@ -152,7 +152,7 @@ INCLUDEPATH += $$PROTOBUF_PATH/include
 # LIBS += -L$$PWD/src/libs/pdm/libs/Windows/x32/MT/ -lpdm -lplatform_pdm_proto_wrapper
 # INCLUDEPATH += $$PWD/src/libs/pdm/include
 # INCLUDEPATH += $$PWD/src/libs/pdm/include/generated
-PDM_PATH = c:/eve_installer/pdm-proto
+PDM_PATH = c:/eve_installer/pdm-proto/1.1.5
 LIBS += -L$$PDM_PATH/libs/Windows/x32/MT/ -lpdm -lplatform_pdm_proto_wrapper
 INCLUDEPATH += $$PDM_PATH/include
 INCLUDEPATH += $$PDM_PATH/include/generated


### PR DESCRIPTION
Updated installerfw.pri to point to the versioned location of the protobuf and pdm library. See EO-10082 for more information