### PR TITLE
🐛 Incorrect variable name fixed

### DIFF
--- a/src/sdk/main.cpp
+++ b/src/sdk/main.cpp
@@ -243,7 +243,7 @@ int main(int argc, char *argv[])
         if (parser.isSet(QLatin1String(CommandLineOptions::ProtoMessagesShort))
             || parser.isSet(QLatin1String(CommandLineOptions::ProtoMessagesLong)))
         {
-            QString url = processUrl(parser.value(QLatin1String(CommandLineOptions::ProtoMessages)));
+            QString url = processUrl(parser.value(QLatin1String(CommandLineOptions::ProtoMessagesShort)));
             QInstaller::setProtoMessageEndpoint(url);
         }
 


### PR DESCRIPTION
Trying to call a variable with invalid name caused build errors