### PR TITLE
EO-11387

### DIFF
--- a/src/libs/installer/packagemanagercoredata.cpp
+++ b/src/libs/installer/packagemanagercoredata.cpp
@@ -35,6 +35,7 @@
 #include <QDesktopServices>
 #include <QDir>
 #include <QRegExp>
+#include <QSettings>
 
 #ifdef Q_OS_WIN
 # include <windows.h>
@@ -79,17 +80,27 @@ PackageManagerCoreData::PackageManagerCoreData(const QHash<QString, QString> &va
     m_variables.insert(QLatin1String("WatermarkPixmap"), m_settings.watermark());
     m_variables.insert(QLatin1String("BannerPixmap"), m_settings.banner());
 
-    // fill in start menu location
-    QString startMenuPath;
-    if (m_variables.value(scAllUsers, scFalse) == scTrue)
+    // When showing the custom introduction page, we need to have the start menu path complete
+    // from the start. When showing the regular intro, we don't want the entire path at the start
+    QSettings confInternal(QLatin1String(":/config/config-internal.ini"), QSettings::IniFormat);
+    if (confInternal.value(QLatin1String("customIntroductionPage"), false).toBool())
     {
-        startMenuPath = m_variables.value(QLatin1String("AllUserStartMenuProgramsPath"));
+        // fill in start menu location
+        QString startMenuPath;
+        if (m_variables.value(scAllUsers, scFalse) == scTrue)
+        {
+            startMenuPath = m_variables.value(QLatin1String("AllUserStartMenuProgramsPath"));
+        }
+        else
+        {
+            startMenuPath = m_variables.value(QLatin1String("UserStartMenuProgramsPath"));
+        }
+        m_variables.insert(scStartMenuDir, startMenuPath + QDir::separator() + m_settings.startMenuDir());
     }
     else
     {
-        startMenuPath = m_variables.value(QLatin1String("UserStartMenuProgramsPath"));
+        m_variables.insert(scStartMenuDir, m_settings.startMenuDir());
     }
-    m_variables.insert(scStartMenuDir, startMenuPath + QDir::separator() + m_settings.startMenuDir());
 
     const QString description = m_settings.runProgramDescription();
     if (!description.isEmpty())

--- a/src/sdk/installerbasecommons.cpp
+++ b/src/sdk/installerbasecommons.cpp
@@ -55,16 +55,23 @@ InstallerGui::InstallerGui(PackageManagerCore *core)
     }
     else
     {
-       setPage(PackageManagerCore::Introduction, new IntroductionPage(core));
+        setPage(PackageManagerCore::Introduction, new IntroductionPage(core));
+        // We don't want the target directory and component selection pages if using the custom introduction page
+        setPage(PackageManagerCore::TargetDirectory, new TargetDirectoryPage(core));
+        setPage(PackageManagerCore::ComponentSelection, new ComponentSelectionPage(core));
+    }
+    
+    setPage(PackageManagerCore::LicenseCheck, new LicenseAgreementPage(core));
+
+    // We also don't want the start menu and ready pages if using the custom introduction page
+    if (!core->useCustomIntroductionPage())
+    {
+#ifdef Q_OS_WIN
+        setPage(PackageManagerCore::StartMenuSelection, new StartMenuDirectoryPage(core));
+#endif
+        setPage(PackageManagerCore::ReadyForInstallation, new ReadyForInstallationPage(core));
     }
 
-    setPage(PackageManagerCore::TargetDirectory, new TargetDirectoryPage(core));
-    setPage(PackageManagerCore::ComponentSelection, new ComponentSelectionPage(core));
-    setPage(PackageManagerCore::LicenseCheck, new LicenseAgreementPage(core));
-#ifdef Q_OS_WIN
-    setPage(PackageManagerCore::StartMenuSelection, new StartMenuDirectoryPage(core));
-#endif
-    setPage(PackageManagerCore::ReadyForInstallation, new ReadyForInstallationPage(core));
     setPage(PackageManagerCore::PerformInstallation, new PerformInstallationPage(core));
     setPage(PackageManagerCore::InstallationFinished, new FinishedPage(core));
 
@@ -118,7 +125,12 @@ MaintenanceGui::MaintenanceGui(PackageManagerCore *core)
         core->setCompleteUninstallation(true);
     }
 
-    setPage(PackageManagerCore::ReadyForInstallation, new ReadyForInstallationPage(core));
+    // We don't want the ready page if using the custom introduction page
+    if (!core->useCustomIntroductionPage())
+    {
+        setPage(PackageManagerCore::ReadyForInstallation, new ReadyForInstallationPage(core));
+    }
+    
     setPage(PackageManagerCore::PerformInstallation, new PerformInstallationPage(core));
     setPage(PackageManagerCore::InstallationFinished, new FinishedPage(core));
 


### PR DESCRIPTION
Make use of the `-xi` binarycreator cli parameter to decide what pages are included in the installer. This means we also need to make sure to set the start menu path at the correct place in the installer.