### PR TITLE
Button changes

### DIFF
--- a/src/libs/installer/packagemanagercore.cpp
+++ b/src/libs/installer/packagemanagercore.cpp
@@ -2611,6 +2611,16 @@ bool PackageManagerCore::preloadPackages() const
 }
 
 /*!
+    Returns \c true if no cancel button should be present in the installer/uninstaller.
+
+    \sa {installer::noCancelButton}{installer.noCancelButton}
+*/
+bool PackageManagerCore::noCancelButton() const
+{
+    return d->noCancelButton();
+}
+
+/*!
     \sa {installer::setUninstaller}{installer.setUninstaller}
     \sa isUninstaller(), setUpdater(), setPackageManager()
 */

--- a/src/libs/installer/packagemanagercore.cpp
+++ b/src/libs/installer/packagemanagercore.cpp
@@ -2591,6 +2591,16 @@ bool PackageManagerCore::isOfflineOnly() const
 }
 
 /*!
+    Returns \c true if this is our customized installer.
+
+    \sa {installer::isCustomInstaller}{installer.isCustomInstaller}
+*/
+bool PackageManagerCore::isCustomInstaller() const
+{
+    return d->isCustomInstaller();
+}
+
+/*!
     Returns \c true if using the custom introduction page.
 
     \sa {installer::useCustomIntroductionPage}{installer.useCustomIntroductionPage}

--- a/src/libs/installer/packagemanagercore.cpp
+++ b/src/libs/installer/packagemanagercore.cpp
@@ -2621,6 +2621,16 @@ bool PackageManagerCore::noCancelButton() const
 }
 
 /*!
+    Returns \c true if no details should be available in the installer/uninstaller.
+
+    \sa {installer::noDetails}{installer.noDetails}
+*/
+bool PackageManagerCore::noDetails() const
+{
+    return d->noDetails();
+}
+
+/*!
     \sa {installer::setUninstaller}{installer.setUninstaller}
     \sa isUninstaller(), setUpdater(), setPackageManager()
 */

--- a/src/libs/installer/packagemanagercore.h
+++ b/src/libs/installer/packagemanagercore.h
@@ -223,8 +223,11 @@ public:
     // convenience
     Q_INVOKABLE bool isInstaller() const;
     Q_INVOKABLE bool isOfflineOnly() const;
+
+    // Our additions
     Q_INVOKABLE bool useCustomIntroductionPage() const;
     Q_INVOKABLE bool preloadPackages() const;
+    Q_INVOKABLE bool noCancelButton() const;
 
     Q_INVOKABLE void setUninstaller();
     Q_INVOKABLE bool isUninstaller() const;

--- a/src/libs/installer/packagemanagercore.h
+++ b/src/libs/installer/packagemanagercore.h
@@ -225,6 +225,7 @@ public:
     Q_INVOKABLE bool isOfflineOnly() const;
 
     // Our additions
+    Q_INVOKABLE bool isCustomInstaller() const;
     Q_INVOKABLE bool useCustomIntroductionPage() const;
     Q_INVOKABLE bool preloadPackages() const;
     Q_INVOKABLE bool noCancelButton() const;

--- a/src/libs/installer/packagemanagercore.h
+++ b/src/libs/installer/packagemanagercore.h
@@ -228,6 +228,7 @@ public:
     Q_INVOKABLE bool useCustomIntroductionPage() const;
     Q_INVOKABLE bool preloadPackages() const;
     Q_INVOKABLE bool noCancelButton() const;
+    Q_INVOKABLE bool noDetails() const;
 
     Q_INVOKABLE void setUninstaller();
     Q_INVOKABLE bool isUninstaller() const;

--- a/src/libs/installer/packagemanagercore_p.cpp
+++ b/src/libs/installer/packagemanagercore_p.cpp
@@ -634,6 +634,11 @@ bool PackageManagerCorePrivate::isOfflineOnly() const
     return getConfigValueAsBool(QLatin1String("offlineOnly"));
 }
 
+bool PackageManagerCorePrivate::isCustomInstaller() const
+{
+    return getConfigValueAsBool(QLatin1String("customInstaller"));
+}
+
 bool PackageManagerCorePrivate::useCustomIntroductionPage() const
 {
     return getConfigValueAsBool(QLatin1String("customIntroductionPage"));

--- a/src/libs/installer/packagemanagercore_p.cpp
+++ b/src/libs/installer/packagemanagercore_p.cpp
@@ -620,25 +620,33 @@ void PackageManagerCorePrivate::initialize(const QHash<QString, QString> &params
     KDUpdater::FileDownloaderFactory::instance().setProxyFactory(m_core->proxyFactory());
 }
 
+bool getConfigValueAsBool(const QString &key, bool defaultValue = false)
+{
+    QSettings confInternal(QLatin1String(":/config/config-internal.ini"), QSettings::IniFormat);
+    return confInternal.value(key, defaultValue).toBool();
+}
+
 bool PackageManagerCorePrivate::isOfflineOnly() const
 {
     if (!isInstaller())
         return false;
 
-    QSettings confInternal(QLatin1String(":/config/config-internal.ini"), QSettings::IniFormat);
-    return confInternal.value(QLatin1String("offlineOnly"), false).toBool();
+    return getConfigValueAsBool(QLatin1String("offlineOnly"));
 }
 
 bool PackageManagerCorePrivate::useCustomIntroductionPage() const
 {
-    QSettings confInternal(QLatin1String(":/config/config-internal.ini"), QSettings::IniFormat);
-    return confInternal.value(QLatin1String("customIntroductionPage"), false).toBool();
+    return getConfigValueAsBool(QLatin1String("customIntroductionPage"));
 }
 
 bool PackageManagerCorePrivate::preloadPackages() const
 {
-    QSettings confInternal(QLatin1String(":/config/config-internal.ini"), QSettings::IniFormat);
-    return confInternal.value(QLatin1String("preloadPackages"), false).toBool();
+    return getConfigValueAsBool(QLatin1String("preloadPackages"));
+}
+
+bool PackageManagerCorePrivate::noCancelButton() const
+{
+    return getConfigValueAsBool(QLatin1String("noCancelButton"));
 }
 
 QString PackageManagerCorePrivate::installerBinaryPath() const

--- a/src/libs/installer/packagemanagercore_p.cpp
+++ b/src/libs/installer/packagemanagercore_p.cpp
@@ -649,6 +649,11 @@ bool PackageManagerCorePrivate::noCancelButton() const
     return getConfigValueAsBool(QLatin1String("noCancelButton"));
 }
 
+bool PackageManagerCorePrivate::noDetails() const
+{
+    return getConfigValueAsBool(QLatin1String("noDetails"));
+}
+
 QString PackageManagerCorePrivate::installerBinaryPath() const
 {
     return qApp->applicationFilePath();

--- a/src/libs/installer/packagemanagercore_p.h
+++ b/src/libs/installer/packagemanagercore_p.h
@@ -87,6 +87,7 @@ public:
     bool isOfflineOnly() const;
 
     // Our additions
+    bool isCustomInstaller() const;
     bool useCustomIntroductionPage() const;
     bool preloadPackages() const;
     bool noCancelButton() const;

--- a/src/libs/installer/packagemanagercore_p.h
+++ b/src/libs/installer/packagemanagercore_p.h
@@ -86,8 +86,10 @@ public:
     void initialize(const QHash<QString, QString> &params);
     bool isOfflineOnly() const;
 
+    // Our additions
     bool useCustomIntroductionPage() const;
     bool preloadPackages() const;
+    bool noCancelButton() const;
 
     bool statusCanceledOrFailed() const;
     void setStatus(int status, const QString &error = QString());

--- a/src/libs/installer/packagemanagercore_p.h
+++ b/src/libs/installer/packagemanagercore_p.h
@@ -90,6 +90,7 @@ public:
     bool useCustomIntroductionPage() const;
     bool preloadPackages() const;
     bool noCancelButton() const;
+    bool noDetails() const;
 
     bool statusCanceledOrFailed() const;
     void setStatus(int status, const QString &error = QString());

--- a/src/libs/installer/packagemanagergui.cpp
+++ b/src/libs/installer/packagemanagergui.cpp
@@ -336,6 +336,12 @@ PackageManagerGui::PackageManagerGui(PackageManagerCore *core, QWidget *parent)
     setOption(QWizard::NoBackButtonOnStartPage);
     setOption(QWizard::NoBackButtonOnLastPage);
 
+    if (m_core->noCancelButton())
+    {
+        // Remove the cancel button from the installer/uninstaller
+        setOption(QWizard::NoCancelButton);
+    }
+
     connect(this, &QDialog::rejected, m_core, &PackageManagerCore::setCanceled);
     connect(this, &PackageManagerGui::interrupted, m_core, &PackageManagerCore::interrupt);
 
@@ -2285,12 +2291,16 @@ void CustomIntroductionPage::entering()
     showWidgets(false);
     setMessage(QString());
     setErrorMessage(QString());
-    setButtonText(QWizard::CancelButton, tr("&Quit"));
 
     m_progressBar->setValue(0);
     m_progressBar->setRange(0, 0);
     PackageManagerCore *core = packageManagerCore();
     setSettingsButtonRequested((!core->isOfflineOnly()) && (!core->isUninstaller()));
+
+    if (!core->noCancelButton())
+    {
+        setButtonText(QWizard::CancelButton, tr("&Quit"));
+    }
 
     // Ready for installation text
     if (core->isUninstaller()) {
@@ -2318,12 +2328,6 @@ void CustomIntroductionPage::entering()
         m_spaceLabel->setText(tr("Setup is now ready to begin installing %1 on your computer.")
             .arg(productName()));
     }
-
-    // QString htmlOutput;
-    // bool componentsOk = core->calculateComponents(&htmlOutput);
-    // m_taskDetailsBrowser->setHtml(htmlOutput);
-    // m_taskDetailsBrowser->setVisible(!componentsOk || isVerbose());
-    // setComplete(componentsOk);
 
     if (!core->isUninstaller()) {
         QString spaceInfo;
@@ -2354,8 +2358,11 @@ void CustomIntroductionPage::leaving()
     m_progressBar->setValue(0);
     m_progressBar->setRange(0, 0);
 
-    // Resetting the cancel button text from Quit to Cancel
-    setButtonText(QWizard::CancelButton, gui()->defaultButtonText(QWizard::CancelButton));
+    if (!packageManagerCore()->noCancelButton())
+    {
+        // Resetting the cancel button text from Quit to Cancel
+        setButtonText(QWizard::CancelButton, gui()->defaultButtonText(QWizard::CancelButton));
+    }
 
     // Resetting button text (after changing it to Install/Uninstall/Update)
     setButtonText(QWizard::NextButton, gui()->defaultButtonText(QWizard::NextButton));
@@ -3447,7 +3454,7 @@ PerformInstallationPage::PerformInstallationPage(PackageManagerCore *core)
             core, &PackageManagerCore::setAutomatedPageSwitchEnabled);
 
     m_performInstallationForm->setDetailsWidgetVisible(true);
-
+    
     setCommitPage(true);
 }
 

--- a/src/libs/installer/packagemanagergui.cpp
+++ b/src/libs/installer/packagemanagergui.cpp
@@ -1855,6 +1855,9 @@ CustomIntroductionPage::CustomIntroductionPage(PackageManagerCore *core)
         m_taskButton = nullptr;
     }
 #endif
+
+    // By setting this as a commit page, we make sure that the back button on the following page will be disabled
+    setCommitPage(true);
 }
 
 /*!
@@ -2305,7 +2308,7 @@ void CustomIntroductionPage::entering()
     // Ready for installation text
     if (core->isUninstaller()) {
         // m_taskDetailsBrowser->setVisible(false);
-        setButtonText(QWizard::NextButton, tr("U&ninstall"));
+        setButtonText(QWizard::CommitButton, tr("U&ninstall"));
         setColoredTitle(tr("Ready to Uninstall %1").arg(productName()));
         m_spaceLabel->setText(tr("Setup is now ready to begin removing %1 from your computer.<br>"
             "<font color=\"red\">The program directory %2 will be deleted completely</font>, "
@@ -2316,14 +2319,14 @@ void CustomIntroductionPage::entering()
         // setComplete(true);
         // return;
     } else if (core->isMaintainer()) {
-        setButtonText(QWizard::NextButton, tr("U&pdate"));
+        setButtonText(QWizard::CommitButton, tr("U&pdate"));
         // setColoredTitle(tr("Ready to Update Packages"));
         m_spaceLabel->setText(tr("Setup is now ready to begin updating your installation."));
     } else {
         Q_ASSERT(core->isInstaller());
         core->calculateComponentsToInstall();
         showInstallerInformation();
-        setButtonText(QWizard::NextButton, tr("&Install"));
+        setButtonText(QWizard::CommitButton, tr("&Install"));
         // setColoredTitle(tr("Ready to Install"));
         m_spaceLabel->setText(tr("Setup is now ready to begin installing %1 on your computer.")
             .arg(productName()));
@@ -2365,7 +2368,7 @@ void CustomIntroductionPage::leaving()
     }
 
     // Resetting button text (after changing it to Install/Uninstall/Update)
-    setButtonText(QWizard::NextButton, gui()->defaultButtonText(QWizard::NextButton));
+    setButtonText(QWizard::CommitButton, gui()->defaultButtonText(QWizard::CommitButton));
 
     // Store the install location
     packageManagerCore()->setValue(scTargetDir, targetDir());

--- a/src/libs/installer/packagemanagergui.cpp
+++ b/src/libs/installer/packagemanagergui.cpp
@@ -3431,6 +3431,11 @@ PerformInstallationPage::PerformInstallationPage(PackageManagerCore *core)
 
     m_performInstallationForm->setupUi(this);
 
+    if (core->noDetails())
+    {
+        m_performInstallationForm->noDetails();
+    }
+
     connect(ProgressCoordinator::instance(), &ProgressCoordinator::detailTextChanged,
         m_performInstallationForm, &PerformInstallationForm::appendProgressDetails);
     connect(ProgressCoordinator::instance(), &ProgressCoordinator::detailTextResetNeeded,
@@ -3453,7 +3458,10 @@ PerformInstallationPage::PerformInstallationPage(PackageManagerCore *core)
     connect(this, &PerformInstallationPage::setAutomatedPageSwitchEnabled,
             core, &PackageManagerCore::setAutomatedPageSwitchEnabled);
 
-    m_performInstallationForm->setDetailsWidgetVisible(true);
+    if (!core->noDetails())
+    {
+        m_performInstallationForm->setDetailsWidgetVisible(true);
+    }
     
     setCommitPage(true);
 }
@@ -3502,10 +3510,13 @@ void PerformInstallationPage::entering()
         QTimer::singleShot(30, packageManagerCore(), SLOT(runInstaller()));
     }
 
-    m_performInstallationForm->enableDetails();
+    if (!packageManagerCore()->noDetails())
+    {
+        m_performInstallationForm->enableDetails();
+    }
     emit setAutomatedPageSwitchEnabled(true);
 
-    if (isVerbose())
+    if (isVerbose() && !packageManagerCore()->noDetails())
         m_performInstallationForm->toggleDetails();
 }
 

--- a/src/libs/installer/performinstallationform.cpp
+++ b/src/libs/installer/performinstallationform.cpp
@@ -273,3 +273,12 @@ void PerformInstallationForm::onDownloadStatusChanged(const QString &status)
     m_downloadStatus->setText(m_downloadStatus->fontMetrics().elidedText(status, Qt::ElideRight,
         m_downloadStatus->width()));
 }
+
+/*!
+    Removes the show/hide details button along with the details browser
+*/
+void PerformInstallationForm::noDetails() const
+{
+    m_detailsButton->setVisible(false);
+    m_detailsBrowser->setVisible(false);
+}

--- a/src/libs/installer/performinstallationform.h
+++ b/src/libs/installer/performinstallationform.h
@@ -69,6 +69,7 @@ public slots:
     void toggleDetails();
     void clearDetailsBrowser();
     void onDownloadStatusChanged(const QString &status);
+    void noDetails() const;
 
 private:
     QProgressBar *m_progressBar;

--- a/tools/binarycreator/binarycreator.cpp
+++ b/tools/binarycreator/binarycreator.cpp
@@ -661,6 +661,8 @@ static void printUsage()
 
     std::cout << " -xc|--no-cancel            Remove all cancel buttons from the installer/uninstaller" << std::endl;
 
+    std::cout << " -xd|--no-details           Don't offer any details in installer/uninstaller " << std::endl;
+
     std::cout << "  -r|--resources r1,.,rn    include the given resource files into the binary" << std::endl;
 
     std::cout << "  -v|--verbose              Verbose output" << std::endl;
@@ -793,6 +795,7 @@ int main(int argc, char **argv)
     bool customIntroductionPage = false;
     bool preloadPackages = false;
     bool noCancelButton = false;
+    bool noDetails = false;
     QStringList resources;
     QStringList filteredPackages;
     QInstallerTools::FilterType ftype = QInstallerTools::Exclude;
@@ -859,6 +862,8 @@ int main(int argc, char **argv)
             preloadPackages = true;
         } else if (*it == QLatin1String("-xc") || *it == QLatin1String("--no-cancel")) {
             noCancelButton = true;
+        } else if (*it == QLatin1String("-xd") || *it == QLatin1String("--no-details")) {
+            noDetails = true;
         } else if (*it == QLatin1String("-t") || *it == QLatin1String("--template")) {
             ++it;
             if (it == args.end()) {
@@ -1006,6 +1011,8 @@ int main(int argc, char **argv)
             confInternal.setValue(QLatin1String("preloadPackages"), preloadPackages);
             // assume cancel button if --no-cancel not set
             confInternal.setValue(QLatin1String("noCancelButton"), noCancelButton);
+            // assume details are available if --no-details not set
+            confInternal.setValue(QLatin1String("noDetails"), noDetails);
         }
 
 #ifdef Q_OS_MACOS

--- a/tools/binarycreator/binarycreator.cpp
+++ b/tools/binarycreator/binarycreator.cpp
@@ -654,10 +654,12 @@ static void printUsage()
     std::cout << "  -f|--offline-only         Forces the installer to act as an offline installer, " << std::endl;
     std::cout << "                             i.e. never access online repositories" << std::endl;
 
-    std::cout << "  -xi|--custom-intro        Forces the installer to use the custom introduction page" << std::endl;
-    std::cout << "                            If this parameter is not given, the standard page is used" << std::endl;
+    std::cout << " -xi|--custom-intro         Forces the installer to use the custom introduction page" << std::endl;
+    std::cout << "                             If this parameter is not given, the standard page is used" << std::endl;
 
-    std::cout << "  -xp|--preload-packages    Preload all packages before displaying anything " << std::endl;
+    std::cout << " -xp|--preload-packages     Preload all packages before displaying anything " << std::endl;
+
+    std::cout << " -xc|--no-cancel            Remove all cancel buttons from the installer/uninstaller" << std::endl;
 
     std::cout << "  -r|--resources r1,.,rn    include the given resource files into the binary" << std::endl;
 
@@ -790,6 +792,7 @@ int main(int argc, char **argv)
     bool offlineOnly = false;
     bool customIntroductionPage = false;
     bool preloadPackages = false;
+    bool noCancelButton = false;
     QStringList resources;
     QStringList filteredPackages;
     QInstallerTools::FilterType ftype = QInstallerTools::Exclude;
@@ -854,6 +857,8 @@ int main(int argc, char **argv)
             customIntroductionPage = true;
         } else if (*it == QLatin1String("-xp") || *it == QLatin1String("--preload-packages")) {
             preloadPackages = true;
+        } else if (*it == QLatin1String("-xc") || *it == QLatin1String("--no-cancel")) {
+            noCancelButton = true;
         } else if (*it == QLatin1String("-t") || *it == QLatin1String("--template")) {
             ++it;
             if (it == args.end()) {
@@ -999,6 +1004,8 @@ int main(int argc, char **argv)
             confInternal.setValue(QLatin1String("customIntroductionPage"), customIntroductionPage);
             // assume no preloading if --preload-packages not set
             confInternal.setValue(QLatin1String("preloadPackages"), preloadPackages);
+            // assume cancel button if --no-cancel not set
+            confInternal.setValue(QLatin1String("noCancelButton"), noCancelButton);
         }
 
 #ifdef Q_OS_MACOS

--- a/tools/binarycreator/binarycreator.cpp
+++ b/tools/binarycreator/binarycreator.cpp
@@ -654,6 +654,8 @@ static void printUsage()
     std::cout << "  -f|--offline-only         Forces the installer to act as an offline installer, " << std::endl;
     std::cout << "                             i.e. never access online repositories" << std::endl;
 
+    std::cout << "  -x|--custom-installer     Sets all the flags that we use for our reduced installer" << std::endl;
+
     std::cout << " -xi|--custom-intro         Forces the installer to use the custom introduction page" << std::endl;
     std::cout << "                             If this parameter is not given, the standard page is used" << std::endl;
 
@@ -792,6 +794,7 @@ int main(int argc, char **argv)
     QStringList repositoryDirectories;
     bool onlineOnly = false;
     bool offlineOnly = false;
+    bool customInstaller = false;
     bool customIntroductionPage = false;
     bool preloadPackages = false;
     bool noCancelButton = false;
@@ -856,6 +859,12 @@ int main(int argc, char **argv)
             onlineOnly = true;
         } else if (*it == QLatin1String("-f") || *it == QLatin1String("--offline-only")) {
             offlineOnly = true;
+        } else if (*it == QLatin1String("-x") || *it == QLatin1String("--custom-installer")) {
+            customInstaller = true;
+            customIntroductionPage = true;
+            preloadPackages = true;
+            noCancelButton = true;
+            noDetails = true;
         } else if (*it == QLatin1String("-xi") || *it == QLatin1String("--custom-intro")) {
             customIntroductionPage = true;
         } else if (*it == QLatin1String("-xp") || *it == QLatin1String("--preload-packages")) {
@@ -1005,6 +1014,8 @@ int main(int argc, char **argv)
             if (onlineOnly)
                 offlineOnly = !onlineOnly;
             confInternal.setValue(QLatin1String("offlineOnly"), offlineOnly);
+            // assume regular installer if --custom-installer not set
+            confInternal.setValue(QLatin1String("customInstaller"), customInstaller);
             // assume standard introduction page if --custom-intro not set
             confInternal.setValue(QLatin1String("customIntroductionPage"), customIntroductionPage);
             // assume no preloading if --preload-packages not set


### PR DESCRIPTION
## What's new
These changes are about simplifying the installer/uninstaller UI a little bit.
 - No more cancel button (users can still hit the red x in the upper right corner)
 - No more show/hide details button or textbox with details of what is being installed/uninstalled
 - Back button has now been disabled during installation/uninstallation
 - Also added a minor flag to binarycreator to help managing all the custom flags.

## New binarycreator cli parameters
We now have three new parameters for the binarycreator (that can be supplied when building the installer)
### No cancel button
`-xc` or `--no-cancel` can be supplied to tell the framework that it should not include a cancel button in the installer/uninstaller. Users will still have the red x in the upper right corner, to quit at any time in the installer/uninstaller.
### No UI details options
`-xd` or `--no-details` can be supplied to tell the framework that it should remove the show/hide details button from the installer/uninstaller, as well as removing the details textbox.
### Custom installer
`-x` or `--custom-installer` can be supplied to tell the framework that it should turn on all the `custom` flags, that is all flags whose short form starts with an `x`. At time of writing that is `-xi`, `-xp`, `-xc` and `-xd`.
This is also it's own flag, and might be used in the future to tune some minor things that don't warrant their own flags.

## Tickets
EO-11400
 - Removing the cancel button

EO-11399
 - Remove the show/hide details button

EO-11401
 - Disable the back button