### PR TITLE
EO-11386

### DIFF
--- a/src/libs/installer/eventlogger.cpp
+++ b/src/libs/installer/eventlogger.cpp
@@ -333,20 +333,6 @@ void EventLogger::uninstallerShutDown(eve_launcher::uninstaller::Page page, eve_
     m_httpThreadController->lastChanceToFinish();
 }
 
-void EventLogger::uninstallerDetailsDisplayed()
-{
-    auto evt = new eve_launcher::uninstaller::DetailsDisplayed;
-    evt->set_allocated_event_metadata(getEventMetadata());
-    sendAllocatedEvent(evt);
-}
-
-void EventLogger::uninstallerDetailsHidden()
-{
-    auto evt = new eve_launcher::uninstaller::DetailsHidden;
-    evt->set_allocated_event_metadata(getEventMetadata());
-    sendAllocatedEvent(evt);
-}
-
 void EventLogger::uninstallerUninstallationStarted()
 {
     auto evt = new eve_launcher::uninstaller::UninstallationStarted;
@@ -470,20 +456,6 @@ void EventLogger::installerPreparationFinished(int duration)
     auto evt = new eve_launcher::installer::PreparationFinished;
     evt->set_allocated_event_metadata(getEventMetadata());
     evt->set_duration(duration);
-    sendAllocatedEvent(evt);
-}
-
-void EventLogger::installerDetailsDisplayed()
-{
-    auto evt = new eve_launcher::installer::DetailsDisplayed;
-    evt->set_allocated_event_metadata(getEventMetadata());
-    sendAllocatedEvent(evt);
-}
-
-void EventLogger::installerDetailsHidden()
-{
-    auto evt = new eve_launcher::installer::DetailsHidden;
-    evt->set_allocated_event_metadata(getEventMetadata());
     sendAllocatedEvent(evt);
 }
 

--- a/src/libs/installer/eventlogger.h
+++ b/src/libs/installer/eventlogger.h
@@ -25,8 +25,6 @@ public:
     void uninstallerFinishedPageDisplayed();
     void uninstallerFailedPageDisplayed();
     void uninstallerShutDown(eve_launcher::uninstaller::Page page, eve_launcher::uninstaller::ShutDown_State state, bool finishButton);
-    void uninstallerDetailsDisplayed();
-    void uninstallerDetailsHidden();
     void uninstallerUninstallationStarted();
     void uninstallerUninstallationInterrupted(int duration);
     void uninstallerUninstallationFinished(int duration);
@@ -44,8 +42,6 @@ public:
     void installerShutDown(eve_launcher::installer::Page page, eve_launcher::installer::ShutDown_State state, bool finishButton);
     void installerPreparationStarted();
     void installerPreparationFinished(int duration);
-    void installerDetailsDisplayed();
-    void installerDetailsHidden();
     void installerAutoRunEnabled();
     void installerAutoRunDisabled();
     void installerEulaAccepted();

--- a/src/libs/installer/installereventoperation.cpp
+++ b/src/libs/installer/installereventoperation.cpp
@@ -167,14 +167,6 @@ bool InstallerEventOperation::sendUninstallerEvent(QStringList args)
 
         EventLogger::instance()->uninstallerShutDown(page, state, finishButton);
     }
-    else if (event == QString::fromLatin1("DetailsDisplayed"))
-    {
-        EventLogger::instance()->uninstallerDetailsDisplayed();
-    }
-    else if (event == QString::fromLatin1("DetailsHidden"))
-    {
-        EventLogger::instance()->uninstallerDetailsHidden();
-    }
     else if (event == QString::fromLatin1("UninstallationStarted"))
     {
         EventLogger::instance()->uninstallerUninstallationStarted();
@@ -291,14 +283,6 @@ bool InstallerEventOperation::sendInstallerEvent(QStringList args)
         if (!ok) return false;
 
         EventLogger::instance()->installerPreparationFinished(duration);
-    }
-    else if (event == QString::fromLatin1("DetailsDisplayed"))
-    {
-        EventLogger::instance()->installerDetailsDisplayed();
-    }
-    else if (event == QString::fromLatin1("DetailsHidden"))
-    {
-        EventLogger::instance()->installerDetailsHidden();
     }
     else if (event == QString::fromLatin1("AutoRunEnabled"))
     {

--- a/src/libs/installer/packagemanagergui.cpp
+++ b/src/libs/installer/packagemanagergui.cpp
@@ -2326,7 +2326,7 @@ void CustomIntroductionPage::entering()
     if (core->isUninstaller()) {
         // m_taskDetailsBrowser->setVisible(false);
         setButtonText(QWizard::CommitButton, tr("U&ninstall"));
-        setColoredTitle(tr("Ready to Uninstall %1").arg(productName()));
+        setColoredTitle(tr("Ready to Uninstall"));
         m_spaceLabel->setText(tr("Setup is now ready to begin removing %1 from your computer.<br>"
             "<font color=\"red\">%2 will be deleted completely</font>, "
             "including all content in that directory!")

--- a/src/libs/installer/packagemanagergui.cpp
+++ b/src/libs/installer/packagemanagergui.cpp
@@ -302,13 +302,25 @@ PackageManagerGui::PackageManagerGui(PackageManagerCore *core, QWidget *parent)
 {
     if (m_core->isInstaller())
     {
-        // setWindowTitle(tr("%1 Setup").arg(m_core->value(scTitle)));
-        setWindowTitle(tr("EVE Online Launcher Setup")); // todo use the custominstaller flag
+        if (m_core->isCustomInstaller())
+        {
+            setWindowTitle(tr("EVE Online Launcher Setup"));
+        }
+        else 
+        {
+            setWindowTitle(tr("%1 Setup").arg(m_core->value(scTitle)));
+        }
     }
     else
     {
-        // setWindowTitle(tr("Maintain %1").arg(m_core->value(scTitle)));
-        setWindowTitle(tr("EVE Online Uninstaller")); // todo use the custominstaller flag
+        if (m_core->isCustomInstaller())
+        {
+            setWindowTitle(tr("EVE Online Uninstaller"));
+        }
+        else 
+        {
+            setWindowTitle(tr("Maintain %1").arg(m_core->value(scTitle)));
+        }
     }
     setWindowFlags(windowFlags() &~ Qt::WindowContextHelpButtonHint);
 
@@ -2316,7 +2328,7 @@ void CustomIntroductionPage::entering()
         setButtonText(QWizard::CommitButton, tr("U&ninstall"));
         setColoredTitle(tr("Ready to Uninstall %1").arg(productName()));
         m_spaceLabel->setText(tr("Setup is now ready to begin removing %1 from your computer.<br>"
-            "<font color=\"red\">The program directory %2 will be deleted completely</font>, "
+            "<font color=\"red\">%2 will be deleted completely</font>, "
             "including all content in that directory!")
             .arg(productName(),
                 QDir::toNativeSeparators(QDir(core->value(scTargetDir))

--- a/src/libs/installer/packagemanagergui.cpp
+++ b/src/libs/installer/packagemanagergui.cpp
@@ -301,9 +301,15 @@ PackageManagerGui::PackageManagerGui(PackageManagerCore *core, QWidget *parent)
     , m_core(core)
 {
     if (m_core->isInstaller())
-        setWindowTitle(tr("%1 Setup").arg(m_core->value(scTitle)));
+    {
+        // setWindowTitle(tr("%1 Setup").arg(m_core->value(scTitle)));
+        setWindowTitle(tr("EVE Online Launcher Setup")); // todo use the custominstaller flag
+    }
     else
-        setWindowTitle(tr("Maintain %1").arg(m_core->value(scTitle)));
+    {
+        // setWindowTitle(tr("Maintain %1").arg(m_core->value(scTitle)));
+        setWindowTitle(tr("EVE Online Uninstaller")); // todo use the custominstaller flag
+    }
     setWindowFlags(windowFlags() &~ Qt::WindowContextHelpButtonHint);
 
 #ifndef Q_OS_MACOS
@@ -1772,8 +1778,7 @@ CustomIntroductionPage::CustomIntroductionPage(PackageManagerCore *core)
     m_msgLabel = new QLabel(this);
     m_msgLabel->setWordWrap(true);
     m_msgLabel->setObjectName(QLatin1String("MessageLabel"));
-    // m_msgLabel->setText(tr("Welcome to the %1 Setup Wizard.").arg(productName()));
-    m_msgLabel->setText(tr("Please specify the directory where %1 will be installed.").arg(productName()));
+    m_msgLabel->setText(tr("Install location:"));
     layout->addWidget(m_msgLabel);
 
     QHBoxLayout *hlayout = new QHBoxLayout;
@@ -1790,7 +1795,7 @@ CustomIntroductionPage::CustomIntroductionPage(PackageManagerCore *core)
     m_browseButton->setObjectName(QLatin1String("BrowseDirectoryButton"));
     connect(m_browseButton, &QAbstractButton::clicked, this, &CustomIntroductionPage::dirRequested);
     m_browseButton->setShortcut(QKeySequence(tr("Alt+R", "browse file system to choose a file")));
-    m_browseButton->setText(tr("B&rowse..."));
+    m_browseButton->setText(tr("Change..."));
     hlayout->addWidget(m_browseButton);
 
     layout->addLayout(hlayout);
@@ -2336,8 +2341,7 @@ void CustomIntroductionPage::entering()
 
     QString installRedistText = core->value(QLatin1String("InstallRedists"), QLatin1String("false"));
     if (installRedistText == QLatin1String("true")) {
-        m_redistLabel->setText(tr("Your system is missing C++ runtime that is needed to run the EVE Launcher, "
-        "so the missing runtime will be installed on your computer as part of the installation."));
+        m_redistLabel->setText(tr("Update for Universal C Runtime in Windows will be installed."));
     } else {
         m_redistLabel->setVisible(false);
     }

--- a/src/sdk/translations/ifw_ca.ts
+++ b/src/sdk/translations/ifw_ca.ts
@@ -2574,7 +2574,8 @@ S&apos;instal·la el component %1...</translation>
   Here we are providing translations for the new installer/uninstaller names.
   ==============================================================================================
 -->
-<name>QInstaller::PackageManagerGui</name>
+<context>
+    <name>QInstaller::PackageManagerGui</name>
     <message>
         <source>EVE Online Launcher Setup</source>
         <translation type="unfinished"></translation>
@@ -2654,8 +2655,8 @@ S&apos;instal·la el component %1...</translation>
         <translation>Llest per a desinstal·lar</translation>
     </message>
     <message>
-        <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;The program directory %2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
-        <translation>El programa d&apos;instal·lació està preparat per a començar a eliminar %1 de l&apos;ordinador.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;El directori del programa %2 se suprimirà completament&lt;/font&gt;, incloent tot el contingut d&apos;aquest directori.</translation>
+        <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;%2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
+        <translation type="unfinished">El programa d&apos;instal·lació està preparat per a començar a eliminar %1 de l&apos;ordinador.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;El directori del programa %2 se suprimirà completament&lt;/font&gt;, incloent tot el contingut d&apos;aquest directori.</translation>
     </message>
     <message>
         <source>U&amp;pdate</source>

--- a/src/sdk/translations/ifw_ca.ts
+++ b/src/sdk/translations/ifw_ca.ts
@@ -2569,6 +2569,30 @@ S&apos;instal·la el component %1...</translation>
 
 <!--
   ==============================================================================================
+  === | START | QInstaller::PackageManagerGui | ================================================
+  ==============================================================================================
+  Here we are providing translations for the new installer/uninstaller names.
+  ==============================================================================================
+-->
+<name>QInstaller::PackageManagerGui</name>
+    <message>
+        <source>EVE Online Launcher Setup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVE Online Uninstaller</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<!--
+  ==============================================================================================
+  === | END | QInstaller::PackageManagerGui | ==================================================
+  ==============================================================================================
+-->
+
+
+<!--
+  ==============================================================================================
   === | START | CustomIntroductionPage | =======================================================
   ==============================================================================================
   We have added our own CustomIntroductionPage, and since we want to make use of the
@@ -2662,8 +2686,8 @@ S&apos;instal·la el component %1...</translation>
         <translation>Carpeta d&apos;instal·lació</translation>
     </message>
     <message>
-        <source>Please specify the directory where %1 will be installed.</source>
-        <translation>Especifiqueu el directori en el que s&apos;instal·larà %1.</translation>
+        <source>Install location:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Alt+R</source>
@@ -2671,8 +2695,8 @@ S&apos;instal·la el component %1...</translation>
         <translation>Alt+X</translation>
     </message>
     <message>
-        <source>B&amp;rowse...</source>
-        <translation>E&amp;xplora...</translation>
+        <source>Change...</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The directory you selected already exists and contains an installation. Choose a different target for installation.</source>
@@ -2739,6 +2763,14 @@ Voleu continuar?</translation>
     <message>
         <source>Error</source>
         <translation>Error</translation>
+    </message>
+    <message>
+        <source>Update for Universal C Runtime in Windows will be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Required, %2 Available.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <!--

--- a/src/sdk/translations/ifw_da.ts
+++ b/src/sdk/translations/ifw_da.ts
@@ -2541,6 +2541,30 @@ Installerer komponenten %1...</translation>
 
 <!--
   ==============================================================================================
+  === | START | QInstaller::PackageManagerGui | ================================================
+  ==============================================================================================
+  Here we are providing translations for the new installer/uninstaller names.
+  ==============================================================================================
+-->
+<name>QInstaller::PackageManagerGui</name>
+    <message>
+        <source>EVE Online Launcher Setup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVE Online Uninstaller</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<!--
+  ==============================================================================================
+  === | END | QInstaller::PackageManagerGui | ==================================================
+  ==============================================================================================
+-->
+
+
+<!--
+  ==============================================================================================
   === | START | CustomIntroductionPage | =======================================================
   ==============================================================================================
   We have added our own CustomIntroductionPage, and since we want to make use of the
@@ -2658,8 +2682,8 @@ Installerer komponenten %1...</translation>
         <translation>Installationsmappe</translation>
     </message>
     <message>
-        <source>Please specify the directory where %1 will be installed.</source>
-        <translation>Angiv venligst mappen hvor %1 skal installeres.</translation>
+        <source>Install location:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Alt+R</source>
@@ -2667,8 +2691,8 @@ Installerer komponenten %1...</translation>
         <translation>Alt+G</translation>
     </message>
     <message>
-        <source>B&amp;rowse...</source>
-        <translation>&amp;Gennemse...</translation>
+        <source>Change...</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The directory you selected already exists and contains an installation. Choose a different target for installation.</source>
@@ -2735,6 +2759,14 @@ Vil du fortsætte?</translation>
     <message>
         <source>Error</source>
         <translation>Fejl</translation>
+    </message>
+    <message>
+        <source>Update for Universal C Runtime in Windows will be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Required, %2 Available.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <!--

--- a/src/sdk/translations/ifw_da.ts
+++ b/src/sdk/translations/ifw_da.ts
@@ -2546,7 +2546,8 @@ Installerer komponenten %1...</translation>
   Here we are providing translations for the new installer/uninstaller names.
   ==============================================================================================
 -->
-<name>QInstaller::PackageManagerGui</name>
+<context>
+    <name>QInstaller::PackageManagerGui</name>
     <message>
         <source>EVE Online Launcher Setup</source>
         <translation type="unfinished"></translation>
@@ -2626,8 +2627,8 @@ Installerer komponenten %1...</translation>
         <translation>Klar til afinstallation</translation>
     </message>
     <message>
-        <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;The program directory %2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
-        <translation>Opsætningen er nu klar til at begynde fjernelsen af %1 fra din computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;Programmappen %2 slettes fuldstændigt&lt;/font&gt;, inklusiv alt indhold i mappen!</translation>
+        <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;%2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
+        <translation type="unfinished">Opsætningen er nu klar til at begynde fjernelsen af %1 fra din computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;Programmappen %2 slettes fuldstændigt&lt;/font&gt;, inklusiv alt indhold i mappen!</translation>
     </message>
     <message>
         <source>U&amp;pdate</source>

--- a/src/sdk/translations/ifw_de.ts
+++ b/src/sdk/translations/ifw_de.ts
@@ -2560,7 +2560,8 @@ Komponente %1 wird installiert...</translation>
   Here we are providing translations for the new installer/uninstaller names.
   ==============================================================================================
 -->
-<name>QInstaller::PackageManagerGui</name>
+<context>
+    <name>QInstaller::PackageManagerGui</name>
     <message>
         <source>EVE Online Launcher Setup</source>
         <translation>Einrichtung des EVE Online Launchers</translation>
@@ -2640,8 +2641,8 @@ Komponente %1 wird installiert...</translation>
         <translation>Bereit zum Deinstallieren</translation>
     </message>
     <message>
-        <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;The program directory %2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
-        <translation>Das Einrichtungsprogramm ist jetzt bereit, %1 von Ihrem Computer zu entfernen. &lt;br&gt;&lt;font color=&quot;red&quot;&gt;Das Programmverzeichnis %2 wird vollständig gelöscht&lt;/font&gt;, inklusive allen Inhalten in diesem Verzeichnis!</translation>
+        <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;%2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
+        <translation type="unfinished">Das Einrichtungsprogramm ist jetzt bereit, %1 von Ihrem Computer zu entfernen. &lt;br&gt;&lt;font color=&quot;red&quot;&gt;Das Programmverzeichnis %2 wird vollständig gelöscht&lt;/font&gt;, inklusive allen Inhalten in diesem Verzeichnis!</translation>
     </message>
     <message>
         <source>U&amp;pdate</source>

--- a/src/sdk/translations/ifw_de.ts
+++ b/src/sdk/translations/ifw_de.ts
@@ -2555,6 +2555,30 @@ Komponente %1 wird installiert...</translation>
 
 <!--
   ==============================================================================================
+  === | START | QInstaller::PackageManagerGui | ================================================
+  ==============================================================================================
+  Here we are providing translations for the new installer/uninstaller names.
+  ==============================================================================================
+-->
+<name>QInstaller::PackageManagerGui</name>
+    <message>
+        <source>EVE Online Launcher Setup</source>
+        <translation>Einrichtung des EVE Online Launchers</translation>
+    </message>
+    <message>
+        <source>EVE Online Uninstaller</source>
+        <translation>EVE Online Deinstallationsprogramm</translation>
+    </message>
+</context>
+<!--
+  ==============================================================================================
+  === | END | QInstaller::PackageManagerGui | ==================================================
+  ==============================================================================================
+-->
+
+
+<!--
+  ==============================================================================================
   === | START | CustomIntroductionPage | =======================================================
   ==============================================================================================
   We have added our own CustomIntroductionPage, and since we want to make use of the
@@ -2672,8 +2696,8 @@ Komponente %1 wird installiert...</translation>
         <translation>Installationsordner</translation>
     </message>
     <message>
-        <source>Please specify the directory where %1 will be installed.</source>
-        <translation>Bitte geben Sie den Verzeichnis an, in dem %1 installiert werden soll.</translation>
+        <source>Install location:</source>
+        <translation>Installationsort:</translation>
     </message>
     <message>
         <source>Alt+R</source>
@@ -2682,8 +2706,8 @@ Komponente %1 wird installiert...</translation>
         <translation>Alt+D</translation>
     </message>
     <message>
-        <source>B&amp;rowse...</source>
-        <translation>&amp;Durchsuchen ...</translation>
+        <source>Change...</source>
+        <translation>Ändern ...</translation>
     </message>
     <message>
         <source>The directory you selected already exists and contains an installation. Choose a different target for installation.</source>
@@ -2750,6 +2774,14 @@ Möchten Sie trotzdem fortsetzen?</translation>
      <message>
         <source>Error</source>
         <translation>Fehler</translation>
+    </message>
+    <message>
+        <source>Update for Universal C Runtime in Windows will be installed.</source>
+        <translation>Update für universelle C-Laufzeit in Windows wird installiert.</translation>
+    </message>
+    <message>
+        <source>%1 Required, %2 Available.</source>
+        <translation>%1 benötigt, %2 verfügbar.</translation>
     </message>
 </context>
 <!--

--- a/src/sdk/translations/ifw_es.ts
+++ b/src/sdk/translations/ifw_es.ts
@@ -2522,6 +2522,30 @@ Instalando componente %1...</translation>
 
 <!--
   ==============================================================================================
+  === | START | QInstaller::PackageManagerGui | ================================================
+  ==============================================================================================
+  Here we are providing translations for the new installer/uninstaller names.
+  ==============================================================================================
+-->
+<name>QInstaller::PackageManagerGui</name>
+    <message>
+        <source>EVE Online Launcher Setup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVE Online Uninstaller</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<!--
+  ==============================================================================================
+  === | END | QInstaller::PackageManagerGui | ==================================================
+  ==============================================================================================
+-->
+
+
+<!--
+  ==============================================================================================
   === | START | CustomIntroductionPage | =======================================================
   ==============================================================================================
   We have added our own CustomIntroductionPage, and since we want to make use of the
@@ -2639,8 +2663,8 @@ Instalando componente %1...</translation>
         <translation>Carpeta de instalación</translation>
     </message>
     <message>
-        <source>Please specify the directory where %1 will be installed.</source>
-        <translation>Especifique el directorio en el que se instalará %1.</translation>
+        <source>Install location:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Alt+R</source>
@@ -2648,8 +2672,8 @@ Instalando componente %1...</translation>
         <translation>Alt+R</translation>
     </message>
     <message>
-        <source>B&amp;rowse...</source>
-        <translation>Examina&amp;r...</translation>
+        <source>Change...</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The directory you selected already exists and contains an installation. Choose a different target for installation.</source>
@@ -2716,6 +2740,14 @@ No es recomendable instalar en este directorio, ya que la instalación podría g
     <message>
         <source>Error</source>
         <translation>Error</translation>
+    </message>
+    <message>
+        <source>Update for Universal C Runtime in Windows will be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Required, %2 Available.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <!--

--- a/src/sdk/translations/ifw_es.ts
+++ b/src/sdk/translations/ifw_es.ts
@@ -2527,7 +2527,8 @@ Instalando componente %1...</translation>
   Here we are providing translations for the new installer/uninstaller names.
   ==============================================================================================
 -->
-<name>QInstaller::PackageManagerGui</name>
+<context>
+    <name>QInstaller::PackageManagerGui</name>
     <message>
         <source>EVE Online Launcher Setup</source>
         <translation type="unfinished"></translation>
@@ -2607,8 +2608,8 @@ Instalando componente %1...</translation>
         <translation>Preparado para desinstalar</translation>
     </message>
     <message>
-        <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;The program directory %2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
-        <translation>El programa de instalación está preparado para empezar a eliminar %1 del equipo.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;El directorio del programa %2 se eliminará completamente&lt;/font&gt;, incluido todo el contenido del directorio.</translation>
+        <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;%2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
+        <translation type="unfinished">El programa de instalación está preparado para empezar a eliminar %1 del equipo.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;El directorio del programa %2 se eliminará completamente&lt;/font&gt;, incluido todo el contenido del directorio.</translation>
     </message>
     <message>
         <source>U&amp;pdate</source>

--- a/src/sdk/translations/ifw_fr.ts
+++ b/src/sdk/translations/ifw_fr.ts
@@ -2522,6 +2522,30 @@ Installation du composant %1...</translation>
 
 <!--
   ==============================================================================================
+  === | START | QInstaller::PackageManagerGui | ================================================
+  ==============================================================================================
+  Here we are providing translations for the new installer/uninstaller names.
+  ==============================================================================================
+-->
+<name>QInstaller::PackageManagerGui</name>
+    <message>
+        <source>EVE Online Launcher Setup</source>
+        <translation>Installation du lanceur d'EVE Online</translation>
+    </message>
+    <message>
+        <source>EVE Online Uninstaller</source>
+        <translation>Programme de désinstallation d'EVE Online</translation>
+    </message>
+</context>
+<!--
+  ==============================================================================================
+  === | END | QInstaller::PackageManagerGui | ==================================================
+  ==============================================================================================
+-->
+
+
+<!--
+  ==============================================================================================
   === | START | CustomIntroductionPage | =======================================================
   ==============================================================================================
   We have added our own CustomIntroductionPage, and since we want to make use of the
@@ -2639,8 +2663,8 @@ Installation du composant %1...</translation>
         <translation>Dossier d’installation</translation>
     </message>
     <message>
-        <source>Please specify the directory where %1 will be installed.</source>
-        <translation>Spécifiez le répertoire dans lequel %1 va être installé.</translation>
+        <source>Install location:</source>
+        <translation>Emplacement de l'installation :</translation>
     </message>
     <message>
         <source>Alt+R</source>
@@ -2648,8 +2672,8 @@ Installation du composant %1...</translation>
         <translation>Alt+R</translation>
     </message>
     <message>
-        <source>B&amp;rowse...</source>
-        <translation>P&amp;arcourir...</translation>
+        <source>Change...</source>
+        <translation>Changement...</translation>
     </message>
     <message>
         <source>The directory you selected already exists and contains an installation. Choose a different target for installation.</source>
@@ -2716,6 +2740,14 @@ Souhaitez-vous continuer ?</translation>
     <message>
         <source>Error</source>
         <translation>Erreur</translation>
+    </message>
+    <message>
+        <source>Update for Universal C Runtime in Windows will be installed.</source>
+        <translation>La mise à jour pour le Runtime C universel dans Windows va être installée.</translation>
+    </message>
+    <message>
+        <source>%1 Required, %2 Available.</source>
+        <translation>%1 requis, %2 disponible(s).</translation>
     </message>
 </context>
 <!--

--- a/src/sdk/translations/ifw_fr.ts
+++ b/src/sdk/translations/ifw_fr.ts
@@ -2527,7 +2527,8 @@ Installation du composant %1...</translation>
   Here we are providing translations for the new installer/uninstaller names.
   ==============================================================================================
 -->
-<name>QInstaller::PackageManagerGui</name>
+<context>
+    <name>QInstaller::PackageManagerGui</name>
     <message>
         <source>EVE Online Launcher Setup</source>
         <translation>Installation du lanceur d'EVE Online</translation>
@@ -2607,8 +2608,8 @@ Installation du composant %1...</translation>
         <translation>Prêt pour la désinstallation</translation>
     </message>
     <message>
-        <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;The program directory %2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
-        <translation>Le programme d’installation est maintenant prêt à supprimer %1 de votre ordinateur.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;Le répertoire du programme %2 va être entièrement supprimé&lt;/font&gt;, y compris tout son contenu !</translation>
+        <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;%2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
+        <translation type="unfinished">Le programme d’installation est maintenant prêt à supprimer %1 de votre ordinateur.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;Le répertoire du programme %2 va être entièrement supprimé&lt;/font&gt;, y compris tout son contenu !</translation>
     </message>
     <message>
         <source>U&amp;pdate</source>

--- a/src/sdk/translations/ifw_hr.ts
+++ b/src/sdk/translations/ifw_hr.ts
@@ -2538,7 +2538,8 @@ Instaliranje komponente %1...</translation>
   Here we are providing translations for the new installer/uninstaller names.
   ==============================================================================================
 -->
-<name>QInstaller::PackageManagerGui</name>
+<context>
+    <name>QInstaller::PackageManagerGui</name>
     <message>
         <source>EVE Online Launcher Setup</source>
         <translation type="unfinished"></translation>
@@ -2618,8 +2619,8 @@ Instaliranje komponente %1...</translation>
         <translation>Spremno za deinstaliranje</translation>
     </message>
     <message>
-        <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;The program directory %2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
-        <translation>Postavljanje je sad spremno za uklanjanje %1 s računala.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;Mapa programa %2 će se potpuno izbrisati&lt;/font&gt;, uključujući sav sadržaj mape!</translation>
+        <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;%2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
+        <translation type="unfinished">Postavljanje je sad spremno za uklanjanje %1 s računala.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;Mapa programa %2 će se potpuno izbrisati&lt;/font&gt;, uključujući sav sadržaj mape!</translation>
     </message>
     <message>
         <source>U&amp;pdate</source>

--- a/src/sdk/translations/ifw_hr.ts
+++ b/src/sdk/translations/ifw_hr.ts
@@ -2533,6 +2533,30 @@ Instaliranje komponente %1...</translation>
 
 <!--
   ==============================================================================================
+  === | START | QInstaller::PackageManagerGui | ================================================
+  ==============================================================================================
+  Here we are providing translations for the new installer/uninstaller names.
+  ==============================================================================================
+-->
+<name>QInstaller::PackageManagerGui</name>
+    <message>
+        <source>EVE Online Launcher Setup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVE Online Uninstaller</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<!--
+  ==============================================================================================
+  === | END | QInstaller::PackageManagerGui | ==================================================
+  ==============================================================================================
+-->
+
+
+<!--
+  ==============================================================================================
   === | START | CustomIntroductionPage | =======================================================
   ==============================================================================================
   We have added our own CustomIntroductionPage, and since we want to make use of the
@@ -2650,8 +2674,8 @@ Instaliranje komponente %1...</translation>
         <translation>Mapa za instaliranje</translation>
     </message>
     <message>
-        <source>Please specify the directory where %1 will be installed.</source>
-        <translation>Odredi mapu, gdje će se %1 instalirati.</translation>
+        <source>Install location:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Alt+R</source>
@@ -2659,8 +2683,8 @@ Instaliranje komponente %1...</translation>
         <translation>Alt+R</translation>
     </message>
     <message>
-        <source>B&amp;rowse...</source>
-        <translation>P&amp;retraži …</translation>
+        <source>Change...</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The directory you selected already exists and contains an installation. Choose a different target for installation.</source>
@@ -2727,6 +2751,14 @@ Ne preporučujemo instalirati u ovu mapu, jer instaliranje možda neće uspjeti.
     <message>
         <source>Error</source>
         <translation>Greška</translation>
+    </message>
+    <message>
+        <source>Update for Universal C Runtime in Windows will be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Required, %2 Available.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <!--

--- a/src/sdk/translations/ifw_it.ts
+++ b/src/sdk/translations/ifw_it.ts
@@ -2522,6 +2522,30 @@ Installazione componente %1...</translation>
 
 <!--
   ==============================================================================================
+  === | START | QInstaller::PackageManagerGui | ================================================
+  ==============================================================================================
+  Here we are providing translations for the new installer/uninstaller names.
+  ==============================================================================================
+-->
+<name>QInstaller::PackageManagerGui</name>
+    <message>
+        <source>EVE Online Launcher Setup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVE Online Uninstaller</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<!--
+  ==============================================================================================
+  === | END | QInstaller::PackageManagerGui | ==================================================
+  ==============================================================================================
+-->
+
+
+<!--
+  ==============================================================================================
   === | START | CustomIntroductionPage | =======================================================
   ==============================================================================================
   We have added our own CustomIntroductionPage, and since we want to make use of the
@@ -2639,8 +2663,8 @@ Installazione componente %1...</translation>
         <translation>Cartella di installazione</translation>
     </message>
     <message>
-        <source>Please specify the directory where %1 will be installed.</source>
-        <translation>Specificare la directory in cui %1 verrà installato.</translation>
+        <source>Install location:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Alt+R</source>
@@ -2648,8 +2672,8 @@ Installazione componente %1...</translation>
         <translation>Alt+F</translation>
     </message>
     <message>
-        <source>B&amp;rowse...</source>
-        <translation>S&amp;foglia...</translation>
+        <source>Change...</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The directory you selected already exists and contains an installation. Choose a different target for installation.</source>
@@ -2716,6 +2740,14 @@ Continuare?</translation>
     <message>
         <source>Error</source>
         <translation>Errore</translation>
+    </message>
+    <message>
+        <source>Update for Universal C Runtime in Windows will be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Required, %2 Available.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <!--

--- a/src/sdk/translations/ifw_it.ts
+++ b/src/sdk/translations/ifw_it.ts
@@ -2527,7 +2527,8 @@ Installazione componente %1...</translation>
   Here we are providing translations for the new installer/uninstaller names.
   ==============================================================================================
 -->
-<name>QInstaller::PackageManagerGui</name>
+<context>
+    <name>QInstaller::PackageManagerGui</name>
     <message>
         <source>EVE Online Launcher Setup</source>
         <translation type="unfinished"></translation>
@@ -2607,8 +2608,8 @@ Installazione componente %1...</translation>
         <translation>Pronto alla disinstallazione</translation>
     </message>
     <message>
-        <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;The program directory %2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
-        <translation>Si è ora pronti per iniziare la rimozione di %1 dal computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;La directory del programma %2 verrà eliminata completamente&lt;/font&gt;, incluso tutto il contenuto di tale directory!</translation>
+        <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;%2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
+        <translation type="unfinished">Si è ora pronti per iniziare la rimozione di %1 dal computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;La directory del programma %2 verrà eliminata completamente&lt;/font&gt;, incluso tutto il contenuto di tale directory!</translation>
     </message>
     <message>
         <source>U&amp;pdate</source>

--- a/src/sdk/translations/ifw_ja.ts
+++ b/src/sdk/translations/ifw_ja.ts
@@ -2522,6 +2522,30 @@ Installing component %1...</source>
 
 <!--
   ==============================================================================================
+  === | START | QInstaller::PackageManagerGui | ================================================
+  ==============================================================================================
+  Here we are providing translations for the new installer/uninstaller names.
+  ==============================================================================================
+-->
+<name>QInstaller::PackageManagerGui</name>
+    <message>
+        <source>EVE Online Launcher Setup</source>
+        <translation>EVE Onlineランチャーのセットアップ</translation>
+    </message>
+    <message>
+        <source>EVE Online Uninstaller</source>
+        <translation>EVE Onlineアンインストーラ</translation>
+    </message>
+</context>
+<!--
+  ==============================================================================================
+  === | END | QInstaller::PackageManagerGui | ==================================================
+  ==============================================================================================
+-->
+
+
+<!--
+  ==============================================================================================
   === | START | CustomIntroductionPage | =======================================================
   ==============================================================================================
   We have added our own CustomIntroductionPage, and since we want to make use of the
@@ -2639,8 +2663,8 @@ Installing component %1...</source>
         <translation>インストール フォルダー</translation>
     </message>
     <message>
-        <source>Please specify the directory where %1 will be installed.</source>
-        <translation>%1 をインストールするディレクトリを指定してください。</translation>
+        <source>Install location:</source>
+        <translation>インストール場所：</translation>
     </message>
     <message>
         <source>Alt+R</source>
@@ -2648,8 +2672,8 @@ Installing component %1...</source>
         <translation>Alt + R</translation>
     </message>
     <message>
-        <source>B&amp;rowse...</source>
-        <translation>参照(&amp;R)...</translation>
+        <source>Change...</source>
+        <translation>変更</translation>
     </message>
     <message>
         <source>The directory you selected already exists and contains an installation. Choose a different target for installation.</source>
@@ -2716,6 +2740,14 @@ Do you want to continue?</source>
     <message>
         <source>Error</source>
         <translation>エラー</translation>
+    </message>
+    <message>
+        <source>Update for Universal C Runtime in Windows will be installed.</source>
+        <translation>WindowsのUniversal C Runtimeのアップデートがインストールされます。</translation>
+    </message>
+    <message>
+        <source>%1 Required, %2 Available.</source>
+        <translation>%1必要、%2利用可能</translation>
     </message>
 </context>
 <!--

--- a/src/sdk/translations/ifw_ja.ts
+++ b/src/sdk/translations/ifw_ja.ts
@@ -2527,7 +2527,8 @@ Installing component %1...</source>
   Here we are providing translations for the new installer/uninstaller names.
   ==============================================================================================
 -->
-<name>QInstaller::PackageManagerGui</name>
+<context>
+    <name>QInstaller::PackageManagerGui</name>
     <message>
         <source>EVE Online Launcher Setup</source>
         <translation>EVE Onlineランチャーのセットアップ</translation>
@@ -2607,8 +2608,8 @@ Installing component %1...</source>
         <translation>アンインストールの準備ができました</translation>
     </message>
     <message>
-        <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;The program directory %2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
-        <translation>コンピューターから %1 を削除する準備が整っています。&lt;br&gt;&lt;font color=&quot;red&quot;&gt;プログラム ディレクトリ %2 が完全に削除されます&lt;/font&gt;。このディレクトリ内のコンテンツもすべて削除されます。</translation>
+        <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;%2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
+        <translation type="unfinished">コンピューターから %1 を削除する準備が整っています。&lt;br&gt;&lt;font color=&quot;red&quot;&gt;プログラム ディレクトリ %2 が完全に削除されます&lt;/font&gt;。このディレクトリ内のコンテンツもすべて削除されます。</translation>
     </message>
     <message>
         <source>U&amp;pdate</source>

--- a/src/sdk/translations/ifw_pl.ts
+++ b/src/sdk/translations/ifw_pl.ts
@@ -2527,7 +2527,8 @@ Trwa instalowanie elementu %1...</translation>
   Here we are providing translations for the new installer/uninstaller names.
   ==============================================================================================
 -->
-<name>QInstaller::PackageManagerGui</name>
+<context>
+    <name>QInstaller::PackageManagerGui</name>
     <message>
         <source>EVE Online Launcher Setup</source>
         <translation type="unfinished"></translation>
@@ -2607,8 +2608,8 @@ Trwa instalowanie elementu %1...</translation>
         <translation>Gotowy do dezinstalacji</translation>
     </message>
     <message>
-        <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;The program directory %2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
-        <translation>Instalator jest już gotowy, aby rozpocząć usuwanie %1 z komputera.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;Katalog programu %2 zostanie w całości usunięty&lt;/font&gt;, włącznie z całą zawartością!</translation>
+        <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;%2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
+        <translation type="unfinished">Instalator jest już gotowy, aby rozpocząć usuwanie %1 z komputera.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;Katalog programu %2 zostanie w całości usunięty&lt;/font&gt;, włącznie z całą zawartością!</translation>
     </message>
     <message>
         <source>U&amp;pdate</source>

--- a/src/sdk/translations/ifw_pl.ts
+++ b/src/sdk/translations/ifw_pl.ts
@@ -2522,6 +2522,30 @@ Trwa instalowanie elementu %1...</translation>
 
 <!--
   ==============================================================================================
+  === | START | QInstaller::PackageManagerGui | ================================================
+  ==============================================================================================
+  Here we are providing translations for the new installer/uninstaller names.
+  ==============================================================================================
+-->
+<name>QInstaller::PackageManagerGui</name>
+    <message>
+        <source>EVE Online Launcher Setup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EVE Online Uninstaller</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<!--
+  ==============================================================================================
+  === | END | QInstaller::PackageManagerGui | ==================================================
+  ==============================================================================================
+-->
+
+
+<!--
+  ==============================================================================================
   === | START | CustomIntroductionPage | =======================================================
   ==============================================================================================
   We have added our own CustomIntroductionPage, and since we want to make use of the
@@ -2639,8 +2663,8 @@ Trwa instalowanie elementu %1...</translation>
         <translation>Folder instalacji</translation>
     </message>
     <message>
-        <source>Please specify the directory where %1 will be installed.</source>
-        <translation>Podaj katalog, w którym ma zostać zainstalowany element %1.</translation>
+        <source>Install location:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Alt+R</source>
@@ -2648,8 +2672,8 @@ Trwa instalowanie elementu %1...</translation>
         <translation>Alt+R</translation>
     </message>
     <message>
-        <source>B&amp;rowse...</source>
-        <translation>P&amp;rzeglądaj...</translation>
+        <source>Change...</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The directory you selected already exists and contains an installation. Choose a different target for installation.</source>
@@ -2716,6 +2740,14 @@ Czy chcesz kontynuować?</translation>
     <message>
         <source>Error</source>
         <translation>Błąd</translation>
+    </message>
+    <message>
+        <source>Update for Universal C Runtime in Windows will be installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Required, %2 Available.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <!--

--- a/src/sdk/translations/ifw_ru.ts
+++ b/src/sdk/translations/ifw_ru.ts
@@ -2564,6 +2564,30 @@ Installing component %1...</source>
 
 <!--
   ==============================================================================================
+  === | START | QInstaller::PackageManagerGui | ================================================
+  ==============================================================================================
+  Here we are providing translations for the new installer/uninstaller names.
+  ==============================================================================================
+-->
+<name>QInstaller::PackageManagerGui</name>
+    <message>
+        <source>EVE Online Launcher Setup</source>
+        <translation>Настройка программы запуска EVE Online</translation>
+    </message>
+    <message>
+        <source>EVE Online Uninstaller</source>
+        <translation>Программа удаления EVE Online</translation>
+    </message>
+</context>
+<!--
+  ==============================================================================================
+  === | END | QInstaller::PackageManagerGui | ==================================================
+  ==============================================================================================
+-->
+
+
+<!--
+  ==============================================================================================
   === | START | CustomIntroductionPage | =======================================================
   ==============================================================================================
   We have added our own CustomIntroductionPage, and since we want to make use of the
@@ -2687,8 +2711,8 @@ Installing component %1...</source>
         <translation>Alt+R</translation>
     </message>
     <message>
-        <source>B&amp;rowse...</source>
-        <translation>О&amp;бзор...</translation>
+        <source>Change...</source>
+        <translation>Выбрать...</translation>
     </message>
     <message>
         <source>You have selected an existing file or symlink, please choose a different target for installation.</source>
@@ -2731,8 +2755,8 @@ Installing component %1...</source>
         <translation>Выберите каталог для установки</translation>
     </message>
     <message>
-        <source>Please specify the directory where %1 will be installed.</source>
-        <translation>Укажите каталог для установки %1.</translation>
+        <source>Install location:</source>
+        <translation>Директория для установки:</translation>
     </message>
     <message>
         <source>The directory you selected already exists and contains an installation. Choose a different target for installation.</source>
@@ -2759,6 +2783,14 @@ Do you want to continue?</source>
     <message>
         <source>The installation path must not contain &quot;%1&quot;, please specify a valid directory.</source>
         <translation>Путь к каталогу установки не может содержать «%1». Выберите другой каталог.</translation>
+    </message>
+    <message>
+        <source>Update for Universal C Runtime in Windows will be installed.</source>
+        <translation>Будет установлено обновление Universal C Runtime для Windows.</translation>
+    </message>
+    <message>
+        <source>%1 Required, %2 Available.</source>
+        <translation>Нужно: %1, доступно: %2.</translation>
     </message>
 </context>
 <!--

--- a/src/sdk/translations/ifw_ru.ts
+++ b/src/sdk/translations/ifw_ru.ts
@@ -2569,7 +2569,8 @@ Installing component %1...</source>
   Here we are providing translations for the new installer/uninstaller names.
   ==============================================================================================
 -->
-<name>QInstaller::PackageManagerGui</name>
+<context>
+    <name>QInstaller::PackageManagerGui</name>
     <message>
         <source>EVE Online Launcher Setup</source>
         <translation>Настройка программы запуска EVE Online</translation>
@@ -2649,8 +2650,8 @@ Installing component %1...</source>
         <translation>Всё готово к удалению</translation>
     </message>
     <message>
-        <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;The program directory %2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
-        <translation>Программа установки готова начать удаление %1 с вашего компьютера. &lt;br&gt;&lt;font color=&quot;red&quot;&gt;Директория с программой %2 будет полностью удалена&lt;/font&gt;, включая содержимое этой директории!</translation>
+        <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;%2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
+        <translation type="unfinished">Программа установки готова начать удаление %1 с вашего компьютера. &lt;br&gt;&lt;font color=&quot;red&quot;&gt;Директория с программой %2 будет полностью удалена&lt;/font&gt;, включая содержимое этой директории!</translation>
     </message>
     <message>
         <source>U&amp;pdate</source>

--- a/src/sdk/translations/ifw_zh_CN.ts
+++ b/src/sdk/translations/ifw_zh_CN.ts
@@ -2522,6 +2522,30 @@ Installing component %1...</source>
 
 <!--
   ==============================================================================================
+  === | START | QInstaller::PackageManagerGui | ================================================
+  ==============================================================================================
+  Here we are providing translations for the new installer/uninstaller names.
+  ==============================================================================================
+-->
+<name>QInstaller::PackageManagerGui</name>
+    <message>
+        <source>EVE Online Launcher Setup</source>
+        <translation>《星战前夜：晨曦》启动器设置</translation>
+    </message>
+    <message>
+        <source>EVE Online Uninstaller</source>
+        <translation>《星战前夜：晨曦》卸载器</translation>
+    </message>
+</context>
+<!--
+  ==============================================================================================
+  === | END | QInstaller::PackageManagerGui | ==================================================
+  ==============================================================================================
+-->
+
+
+<!--
+  ==============================================================================================
   === | START | QPlatformTheme | ===============================================================
   ==============================================================================================
   QPlatformTheme is a part of QT, and is usually included in the qtbase_<LOCALE> files.
@@ -2675,8 +2699,8 @@ Installing component %1...</source>
         <translation>安装文件夹</translation>
     </message>
     <message>
-        <source>Please specify the directory where %1 will be installed.</source>
-        <translation>请指定将安装 %1 的目录。</translation>
+        <source>Install location:</source>
+        <translation>安装位置：</translation>
     </message>
     <message>
         <source>Alt+R</source>
@@ -2684,8 +2708,8 @@ Installing component %1...</source>
         <translation>Alt+R</translation>
     </message>
     <message>
-        <source>B&amp;rowse...</source>
-        <translation>浏览(&amp;R)...</translation>
+        <source>Change...</source>
+        <translation>更改...</translation>
     </message>
     <message>
         <source>The directory you selected already exists and contains an installation. Choose a different target for installation.</source>
@@ -2752,6 +2776,14 @@ Do you want to continue?</source>
     <message>
         <source>Error</source>
         <translation>错误</translation>
+    </message>
+    <message>
+        <source>Update for Universal C Runtime in Windows will be installed.</source>
+        <translation>Universal C Runtime Windows更新将被安装。</translation>
+    </message>
+    <message>
+        <source>%1 Required, %2 Available.</source>
+        <translation>需要%1，可用空间%2。</translation>
     </message>
 </context>
 <!--

--- a/src/sdk/translations/ifw_zh_CN.ts
+++ b/src/sdk/translations/ifw_zh_CN.ts
@@ -2527,7 +2527,8 @@ Installing component %1...</source>
   Here we are providing translations for the new installer/uninstaller names.
   ==============================================================================================
 -->
-<name>QInstaller::PackageManagerGui</name>
+<context>
+    <name>QInstaller::PackageManagerGui</name>
     <message>
         <source>EVE Online Launcher Setup</source>
         <translation>《星战前夜：晨曦》启动器设置</translation>
@@ -2643,8 +2644,8 @@ Installing component %1...</source>
         <translation>准备卸载</translation>
     </message>
     <message>
-        <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;The program directory %2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
-        <translation>安装程序现已准备好从您的计算机中移除 %1。&lt;br&gt;&lt;font color=&quot;red&quot;&gt;将彻底删除程序目录 %2&lt;/font&gt;，目录内所有内容也将被删除!</translation>
+        <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;%2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
+        <translation type="unfinished">安装程序现已准备好从您的计算机中移除 %1。&lt;br&gt;&lt;font color=&quot;red&quot;&gt;将彻底删除程序目录 %2&lt;/font&gt;，目录内所有内容也将被删除!</translation>
     </message>
     <message>
         <source>U&amp;pdate</source>


### PR DESCRIPTION
## Improved localization
 - Installer name now `EVE Online Launcher Setup` and localized
 - Uninstaller name now `EVE Online Uninstaller` and localized
 - `Please specify the directory where %1 will be installed` shortened to `Install location:` and localized
 - `Browse...` changed to `Change...` and localized
 - `Your system is missing C++ runtime that is needed to run the EVE Launcher, so the missing runtime will be installed on your computer as part of the installation.` shortened to `Update for Universal C Runtime in Windows will be installed.` and localized for the first time
 - Only showing localizations in `German`, `Russian`, `French`, `Japanese` and `Chinese`. All other locales will see the installer/uninstaller in `English`
 - `%1 Required, %2 Available.` localized but not in use yet.
 - Removed the show/hide details event that should have been removed along with the show/hide details button
 - Fixed the `Ready to uninstall` localization issue on the first page of the uninstaller.