### PR TITLE
EO-11681

### DIFF
--- a/src/libs/installer/eventlogger.cpp
+++ b/src/libs/installer/eventlogger.cpp
@@ -51,6 +51,7 @@ EventLogger::EventLogger()
            qDebug() << "framework | EventLogger::EventLogger | JourneyId found in filename:" << match.captured(0);
            journeyId = QUuid::fromString(match.captured(0));
            qDebug() << "framework | EventLogger::EventLogger | JourneyId:" << journeyId.toString(QUuid::WithoutBraces);
+           qDebug() << "framework | EventLogger::EventLogger | JourneyId (base64):" << QString(journeyId.toRfc4122().toBase64();
         }
     }
 
@@ -60,10 +61,11 @@ EventLogger::EventLogger()
         qDebug() << "framework | EventLogger::EventLogger | No JourneyId provided, one will be created instead";
         journeyId = QUuid::createUuid();
         qDebug() << "framework | EventLogger::EventLogger | JourneyId:" << journeyId.toString(QUuid::WithoutBraces);
+        qDebug() << "framework | EventLogger::EventLogger | JourneyId (base64):" << QString(journeyId.toRfc4122().toBase64();
     }
 
+    QInstaller::setJourneyId(journeyId);
     m_journeyId = journeyId.toRfc4122();
-    QInstaller::setJourneyId(m_journeyId);
 }
 
 EventLogger::~EventLogger()

--- a/src/libs/installer/packagemanagergui.cpp
+++ b/src/libs/installer/packagemanagergui.cpp
@@ -3571,10 +3571,10 @@ void PerformInstallationPage::installationFinished()
 
     // Store the journey Id in registry
     qDebug() << "framework | PerformInstallationPage::installationFinished | Storing JourneyId to registry";
-    QByteArray journeyId = QInstaller::getJourneyId();
+    QUuid journeyId = QInstaller::getJourneyId();
     QString path = QLatin1String("HKEY_CURRENT_USER\\SOFTWARE\\CCP\\EVE\\");
     QSettingsWrapper settings(path, QSettingsWrapper::NativeFormat);
-    settings.setValue(QLatin1String("InstallerJourneyId"), journeyId);
+    settings.setValue(QLatin1String("InstallerJourneyId"), journeyId.toString(QUuid::WithoutBraces));
     qDebug() << "framework | PerformInstallationPage::installationFinished | JourneyId stored to registry";
 
     if (!isAutoSwitching()) {

--- a/src/libs/installer/utils.cpp
+++ b/src/libs/installer/utils.cpp
@@ -285,14 +285,14 @@ QString QInstaller::getInstallerFileName()
     return installerFileName;
 }
 
-static QByteArray journeyId;
+static QUuid journeyId;
 
-void QInstaller::setJourneyId(const QByteArray& id)
+void QInstaller::setJourneyId(const QUuid& id)
 {
     journeyId = id;
 }
 
-QByteArray QInstaller::getJourneyId()
+QUuid QInstaller::getJourneyId()
 {
     return journeyId;
 }

--- a/src/libs/installer/utils.h
+++ b/src/libs/installer/utils.h
@@ -90,8 +90,8 @@ namespace QInstaller {
     void INSTALLER_EXPORT setInstallerFileName(const QString& fileName);
     QString INSTALLER_EXPORT getInstallerFileName();
 
-    void INSTALLER_EXPORT setJourneyId(const QByteArray& journeyId);
-    QByteArray INSTALLER_EXPORT getJourneyId();
+    void INSTALLER_EXPORT setJourneyId(const QUuid& journeyId);
+    QUuid INSTALLER_EXPORT getJourneyId();
 
     INSTALLER_EXPORT std::ostream& operator<<(std::ostream &os, const QString &string);
 


### PR DESCRIPTION
## JourneyId fix
 - JourneyId is now stored as a string in registry instead of bytearray for easier testing
 - JourneyId is now stored as QUuid in installer to make it easier to switch between string, bytearray and base64
 - Now additionally log the JourneyId as base64