### PR TITLE
New uninstaller localizations

### DIFF
--- a/src/sdk/translations/ifw_de.ts
+++ b/src/sdk/translations/ifw_de.ts
@@ -2646,7 +2646,7 @@ Komponente %1 wird installiert...</translation>
     </message>
     <message>
         <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;%2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
-        <translation type="unfinished">Das Einrichtungsprogramm ist jetzt bereit, %1 von Ihrem Computer zu entfernen. &lt;br&gt;&lt;font color=&quot;red&quot;&gt;Das Programmverzeichnis %2 wird vollständig gelöscht&lt;/font&gt;, inklusive allen Inhalten in diesem Verzeichnis!</translation>
+        <translation>Einrichtung ist jetzt bereit, mit dem Entfernen von %1 von Ihrem Computer zu beginnen.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;%2 wird vollständig gelöscht&lt;/font&gt;, inklusive aller Inhalte in dem Verzeichnis!</translation>
     </message>
     <message>
         <source>U&amp;pdate</source>

--- a/src/sdk/translations/ifw_fr.ts
+++ b/src/sdk/translations/ifw_fr.ts
@@ -2613,7 +2613,7 @@ Installation du composant %1...</translation>
     </message>
     <message>
         <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;%2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
-        <translation type="unfinished">Le programme d’installation est maintenant prêt à supprimer %1 de votre ordinateur.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;Le répertoire du programme %2 va être entièrement supprimé&lt;/font&gt;, y compris tout son contenu !</translation>
+        <translation>Le désinstallateur est désormais prêt à supprimer %1 de votre ordinateur.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;Le désinstallateur supprimera entièrement %2&lt;/font&gt;, y compris tous les contenus de ce répertoire !</translation>
     </message>
     <message>
         <source>U&amp;pdate</source>

--- a/src/sdk/translations/ifw_ja.ts
+++ b/src/sdk/translations/ifw_ja.ts
@@ -2613,7 +2613,7 @@ Installing component %1...</source>
     </message>
     <message>
         <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;%2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
-        <translation type="unfinished">コンピューターから %1 を削除する準備が整っています。&lt;br&gt;&lt;font color=&quot;red&quot;&gt;プログラム ディレクトリ %2 が完全に削除されます&lt;/font&gt;。このディレクトリ内のコンテンツもすべて削除されます。</translation>
+        <translation>これでセットアップが完了し、お使いのコンピュータから%1の削除を開始する準備が整いました。&lt;br&gt;&lt;font color=&quot;red&quot;&gt;%2は、そのディレクトリ内のすべてのコンテンツを含め、削除されます!&lt;/font&gt;</translation>
     </message>
     <message>
         <source>U&amp;pdate</source>

--- a/src/sdk/translations/ifw_ru.ts
+++ b/src/sdk/translations/ifw_ru.ts
@@ -2655,7 +2655,7 @@ Installing component %1...</source>
     </message>
     <message>
         <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;%2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
-        <translation type="unfinished">Программа установки готова начать удаление %1 с вашего компьютера. &lt;br&gt;&lt;font color=&quot;red&quot;&gt;Директория с программой %2 будет полностью удалена&lt;/font&gt;, включая содержимое этой директории!</translation>
+        <translation>Программа установки готова к удалению директории %1 с вашего компьютера.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;%2 будет удалена полностью&lt;/font&gt;, включая всё содержимое этой директории!</translation>
     </message>
     <message>
         <source>U&amp;pdate</source>

--- a/src/sdk/translations/ifw_zh_CN.ts
+++ b/src/sdk/translations/ifw_zh_CN.ts
@@ -2649,7 +2649,7 @@ Installing component %1...</source>
     </message>
     <message>
         <source>Setup is now ready to begin removing %1 from your computer.&lt;br&gt;&lt;font color=&quot;red&quot;&gt;%2 will be deleted completely&lt;/font&gt;, including all content in that directory!</source>
-        <translation type="unfinished">安装程序现已准备好从您的计算机中移除 %1。&lt;br&gt;&lt;font color=&quot;red&quot;&gt;将彻底删除程序目录 %2&lt;/font&gt;，目录内所有内容也将被删除!</translation>
+        <translation>即将从你的计算机中移除%1 。&lt;br&gt;&lt;font color=&quot;red&quot;&gt;%2将被彻底删除&lt;/font&gt;，包括该路径下的所有文件！</translation>
     </message>
     <message>
         <source>U&amp;pdate</source>


### PR DESCRIPTION
## New uninstaller localizations

One text was recently updated in English:
```
Setup is now ready to begin removing %1 from your computer.<br><font color="red">%2 will be deleted completely</font>, including all content in that directory!</source>
```
Translations for this new text (this is the main text on the first page of the uninstaller) are now provided